### PR TITLE
feat(omp): add oh-my-pi agent toolchain with config, templates, and greywall integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
         name: Check XML
       - id: check-yaml
         name: Check YAML
+        exclude: modify_.*\.ya?ml$
       - id: detect-private-key
         name: Detect Private Key
       - id: end-of-file-fixer
@@ -61,11 +62,13 @@ repos:
       - id: yamlfmt
         name: Format YAML
         types: [yaml]
+        exclude: modify_.*\.ya?ml$
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
       - id: yamllint
         name: Lint YAML
+        exclude: modify_.*\.ya?ml$
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.4
     hooks:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Prebuilt images are also published to GHCR and Docker Hub:
   LLM gateway (configured under `[ai.profile.<profile>.models.catalog.local]`)
   as the `local` provider in `opencode.json`, so any catalog model can be
   selected with `--model local/<id>` or routed from a persona override.
+- OMP (oh-my-pi) is a standalone agent installed via mise GitHub backend,
+  pinned to `16.4.8`. `omp-agent` uses the shared `agent-launch` dispatcher with
+  a dedicated `omp` identity. It scrubs inherited `PI_*` and `OPENCODE_*` env
+  vars, sets `PI_CODING_AGENT_DIR` to the XDG config root
+  (`~/.config/omp`), rejects unsafe flags and `--profile`/`--config` overrides,
+  and injects `--no-extensions`. Chezmoi manages OMP's legacy `~/.omp` root
+  symlink into the XDG root. Auth is managed independently via `omp /login`.
+  The Greywall policy denies Pi/OpenCode/RPIV state and unrelated auth stores.
 
   For multi-agent workflows, start `tmux` from your project worktree, then
   `opencode-agent factory` inside the tmux session. oh-my-opencode-slim
@@ -162,7 +170,7 @@ See examples in `home/.chezmoidata/base/`, `home/.chezmoidata/os/<distro>/`, and
   - Enable specific: `WITH_DOCKER=true WITH_KUBERNETES=true`
   - Disable specific: `WITHOUT_JAVA=true WITHOUT_NODE=true`
   - Disable all then opt-in: `WITHOUT_TOOLCHAINS=true WITH_PYTHON=true`
-  - AI agents (nested under `ai`): `WITH_PI=true`, `WITHOUT_PI=true`
+  - AI agents (nested under `ai`): `WITH_PI=true`, `WITHOUT_PI=true`, `WITH_OMP=true`, `WITHOUT_OMP=true`
 - Environment detection:
   - Ephemeral/container environments are auto-detected and tagged as `ephemeral`.
   - Non-interactive sessions set `.host.interactive = false` (treated as `headless` in package rules).
@@ -376,6 +384,7 @@ Columns show macOS, Ubuntu, Fedora, and Arch Linux coverage. `✅` means the too
 | [AIPerf](https://github.com/ai-dynamo/aiperf)                      | LLM endpoint benchmarking     | `mise ✅`                      | ✅    | ✅     | ✅     | ✅   |
 | [opencode](https://opencode.ai)                                   | AI coding agent (terminal)    | `mise ✅`                      | ✅    | ✅     | ✅     | ✅   |
 | [pi](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) | Coding agent                  | `mise ✅`                      | ✅    | ✅     | ✅     | ✅   |
+| [omp](https://omp.sh)                                             | oh-my-pi coding agent         | `mise ✅`                      | ✅    | ✅     | ✅     | ✅   |
 | [rtk](https://github.com/rtk-ai/rtk)                              | AI agent toolkit              | `mise ✅` (macOS: `system`)   | ✅    | ✅     | ✅     | ✅   |
 
 ## 🧰 GUI Apps (macOS)

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -7,7 +7,7 @@
 {{- $gpg := dict "sign" "" "encrypt" "" -}}
 {{- $secrets := dict "age" stdinIsATTY "bitwarden" false -}}
 {{- $toolchains := list "ai" "cloud" "docker" "golang" "iac" "java" "kubernetes" "node" "python" "rust" "extra" -}}
-{{- $agents := list "pi" "opencode" -}}
+{{- $agents := list "pi" "opencode" "omp" -}}
 
 {{- $data := . -}}
 {{- range $k := list "personal" "gpg" "host" "toolchains" -}}
@@ -199,6 +199,7 @@
 {{- $agentIcons := dict
     "pi"       "🥧"
     "opencode" "🔗"
+    "omp"      "⚡"
 -}}
 {{- $agentsSelected := list -}}
 {{- if stdinIsATTY -}}

--- a/home/.chezmoidata/base/ai/agents/omp.toml
+++ b/home/.chezmoidata/base/ai/agents/omp.toml
@@ -1,0 +1,100 @@
+[ai.base.agents.omp]
+
+[ai.base.agents.omp.sandbox.network]
+hosts = ["api.openai.com", "auth.openai.com", "opencode.ai"]
+
+[ai.base.agents.omp.sandbox.paths]
+allow_read = [
+  "~/.config/omp/**",
+  "~/.config/agents/**"
+]
+allow_write = [
+  "~/.config/omp",
+  "~/.config/omp/**",
+  # DB sidecars and runtime state
+  "~/.config/omp/agent.db",
+  "~/.config/omp/agent.db-wal",
+  "~/.config/omp/agent.db-shm",
+  # Session/sandbox runtime dirs
+  "~/.local/share/omp",
+  "~/.local/share/omp/**",
+  "/tmp/agents/omp",
+  "/tmp/agents/omp/**"
+]
+deny_read = [
+  "~/.config/pi/**",
+  "~/.config/opencode/**",
+  "~/.config/rpiv-*/**",
+  "~/.local/share/opencode/**",
+  "~/.local/share/pi-lens/**",
+  "~/.config/greywall/**",
+  "~/.local/share/plannotator/**",
+  "~/.local/share/engram/**",
+  "~/.config/age/**",
+  "~/.ssh/**",
+  "~/.gnupg/**",
+  "~/.password-store/**",
+  "~/.config/gh/hosts.yml",
+  "~/.config/git/credentials",
+  "**/.env",
+  "**/.env.*"
+]
+deny_write = [
+  "~/.config/pi/**",
+  "~/.config/opencode/**",
+  "~/.config/agents/**",
+  "~/.config/greywall/**",
+  "~/.config/omp/security.yml"
+]
+
+[ai.base.agents.omp.security]
+disabled_providers = [
+  "claude",
+  "gemini",
+  "github-copilot",
+  "openai-codex",
+  "opencode-go",
+  "openrouter"
+]
+
+[ai.base.agents.omp.security.commands]
+enable_claude_user = false
+enable_claude_project = false
+enable_opencode_user = false
+enable_opencode_project = false
+
+[ai.base.agents.omp.security.mcp]
+enable_project_config = false
+discovery_mode = true
+
+[ai.base.agents.omp.security.skills]
+enabled = true
+enable_skill_commands = true
+enable_codex_user = false
+enable_claude_user = false
+enable_claude_project = false
+enable_pi_user = false
+enable_pi_project = false
+enable_agents_user = false
+enable_agents_project = false
+
+[ai.base.agents.omp.security.startup]
+check_update = false
+setup_wizard = false
+
+[ai.base.agents.omp.security.task]
+max_concurrency = 4
+max_recursion_depth = 3
+
+[ai.base.agents.omp.security.task.isolation]
+mode = "auto"
+
+[ai.base.agents.omp.security.tools]
+approval_mode = "yolo"
+discovery_mode = "auto"
+
+[ai.base.agents.omp.settings]
+theme_dark = "dark-catppuccin"
+theme_light = "light-catppuccin"
+symbol_preset = "nerd"
+web_search = "auto"

--- a/home/.chezmoidata/base/packages/omp.toml
+++ b/home/.chezmoidata/base/packages/omp.toml
@@ -1,0 +1,8 @@
+[packages.base.omp]
+
+[packages.base.omp.omp]
+manager = "mise"
+package = "github:can1357/oh-my-pi"
+pin = "16.4.8"
+version = "omp --version"
+completion = {generate = "omp completions zsh"}

--- a/home/.chezmoidata/profile/personal/ai.toml
+++ b/home/.chezmoidata/profile/personal/ai.toml
@@ -1,2 +1,9 @@
+[ai.profile.personal.agents.omp.security]
+disabled_providers = [
+  "claude",
+  "gemini",
+  "github-copilot"
+]
+
 [ai.profile.personal.credentials]
 inject = ["BRAVE_SEARCH_API_KEY"]

--- a/home/.chezmoidata/profile/work/ai.toml
+++ b/home/.chezmoidata/profile/work/ai.toml
@@ -1,2 +1,11 @@
+[ai.profile.work.agents.omp.security]
+disabled_providers = [
+  "claude",
+  "gemini",
+  "openai-codex",
+  "opencode-go",
+  "openrouter"
+]
+
 [ai.profile.work.credentials]
 inject = ["BRAVE_SEARCH_API_KEY"]

--- a/home/.chezmoiignore.tmpl
+++ b/home/.chezmoiignore.tmpl
@@ -27,15 +27,22 @@ Library
 .local/share/dotfiles/test/test-ai-*.bats
 {{- end }}
 {{- /* Per-agent toolchains: stop managing (and --remove can prune) the whole agent tree. */ -}}
-{{- if not .toolchains.pi }}
+{{- if not (get .toolchains "pi" | default false) }}
 .config/pi/**
 .local/bin/pi-agent
 {{- end }}
-{{- if not .toolchains.opencode }}
+{{- if not (get .toolchains "opencode" | default false) }}
 .config/opencode/**
 .local/bin/opencode-agent
 {{- end }}
-{{- if and (not .toolchains.pi) (not .toolchains.opencode) }}
+{{- if not (get .toolchains "omp" | default false) }}
+.config/omp/**
+.local/bin/omp-agent
+{{- end }}
+{{- $hasPi := get .toolchains "pi" | default false -}}
+{{- $hasOc := get .toolchains "opencode" | default false -}}
+{{- $hasOmp := get .toolchains "omp" | default false -}}
+{{- if and (not $hasPi) (not $hasOc) (not $hasOmp) }}
 .local/bin/agent-launch
 {{- end }}
 .gitkeep

--- a/home/.chezmoitemplates/base/ai/merge-greywall-learned-profile
+++ b/home/.chezmoitemplates/base/ai/merge-greywall-learned-profile
@@ -1,10 +1,11 @@
 {{- /* merge-greywall-learned-profile — DRY merge for Greywall learned agent profiles.
   Args:
     root: template data root
-    agent: agent name ("pi" or "opencode")
+    agent: agent name ("pi", "opencode", "omp")
     stdin: raw JSON from stdin (optional; empty string = first-run skeleton)
 
-  Output: merged JSON with agent path/network/credentials overlays + forwardPorts from base.
+  Output: merged JSON with agent path/network/credentials overlays + forwardPorts
+  from base localhost config.
 */ -}}
 {{- $root := .root -}}
 {{- $agent := .agent -}}
@@ -21,9 +22,23 @@
 {{- $agentPaths := dig "sandbox" "paths" dict $agentData -}}
 {{- $allowReadAdditions := index $agentPaths "allow_read" | default list -}}
 {{- $allowWriteAdditions := index $agentPaths "allow_write" | default list -}}
+{{- $denyReadAdditions := index $agentPaths "deny_read" | default list -}}
+{{- $denyWriteAdditions := index $agentPaths "deny_write" | default list -}}
 
 {{- $base = setValueAtPath "filesystem.allowRead" (concat (dig "filesystem" "allowRead" (list) $base) $allowReadAdditions | uniq | sortAlpha) $base -}}
 {{- $base = setValueAtPath "filesystem.allowWrite" (concat (dig "filesystem" "allowWrite" (list) $base) $allowWriteAdditions | uniq | sortAlpha) $base -}}
+{{- $base = setValueAtPath "filesystem.denyRead" (concat (dig "filesystem" "denyRead" (list) $base) $denyReadAdditions | uniq | sortAlpha) $base -}}
+{{- $base = setValueAtPath "filesystem.denyWrite" (concat (dig "filesystem" "denyWrite" (list) $base) $denyWriteAdditions | uniq | sortAlpha) $base -}}
+{{- if eq $agent "omp" -}}
+{{- /* OMP config is modify-managed; remove the stale pre-modify deny entry. */ -}}
+{{-   $filteredDenyWrite := list -}}
+{{-   range $path := (dig "filesystem" "denyWrite" (list) $base) -}}
+{{-     if ne $path "~/.config/omp/config.yml" -}}
+{{-       $filteredDenyWrite = append $filteredDenyWrite $path -}}
+{{-     end -}}
+{{-   end -}}
+{{-   $base = setValueAtPath "filesystem.denyWrite" $filteredDenyWrite $base -}}
+{{- end -}}
 
 {{- /* Network rules */ -}}
 {{- $agentNetwork := dig "sandbox" "network" dict $agentData -}}
@@ -64,7 +79,7 @@
 {{- end -}}
 
 {{- /* Credentials */ -}}
-{{- $creds := includeTemplate "base/ai/render-credentials" $root | mustFromJson -}}
+{{- $creds := includeTemplate "base/ai/render-credentials" (dict "root" $root "agent" $agent) | mustFromJson -}}
 {{- $_ := set $base "credentials" (dict "inject" $creds.inject "secrets" $creds.secrets "ignore" $creds.ignore) -}}
 
 {{- $base | toPrettyJson -}}

--- a/home/.chezmoitemplates/base/ai/render-credentials
+++ b/home/.chezmoitemplates/base/ai/render-credentials
@@ -1,22 +1,37 @@
 {{- /* render-credentials — Merge credential policy and inject enabled provider API key env vars.
-  Usage: {{ includeTemplate "base/ai/render-credentials" . | mustFromJson }}
+  Usage (direct root): {{ includeTemplate "base/ai/render-credentials" . | mustFromJson }}
+  Usage (wrapper):     {{ includeTemplate "base/ai/render-credentials" (dict "root" . "agent" "omp") | mustFromJson }}
   Output: JSON object { inject, secrets, ignore } with sort/dedupe and
-    secrets = base.secrets + profile.secrets - inject - ignore
+    secrets = base.secrets + profile.secrets - inject - ignore.
+
+  When agent is "omp", inject nothing but put all provider credential env vars
+  in secrets so ambient keys are stripped by the sandbox.
 */ -}}
-{{- $credentials := (includeTemplate "base/helpers/load-section" (dict "root" . "section" "ai.credentials" "required" false) | mustFromJson) -}}
-{{- $resolved := includeTemplate "base/ai/resolve-enabled-auth-providers" (dict "root" .) | mustFromJson -}}
-{{- $credInject := concat ($credentials.inject | default list) ($resolved.enabled_api_key_envs | default list) | uniq | sortAlpha -}}
-{{- $credIgnore := $credentials.ignore | default list | uniq | sortAlpha -}}
-{{- $credSecretsRaw := $credentials.secrets | default list | uniq -}}
-{{- $credSecrets := list -}}
-{{- range $s := $credSecretsRaw -}}
-{{-   if and (not (has $s $credInject)) (not (has $s $credIgnore)) -}}
-{{-     $credSecrets = append $credSecrets $s -}}
-{{-   end -}}
+{{- /* Normalize root — accept both direct . and wrapper {root, …} */ -}}
+{{- $root := dig "root" . . -}}
+{{- $agent := dig "agent" "" . -}}
+{{- if eq $agent "omp" -}}
+  {{- /* OMP: collect all provider API key env vars as secrets, inject nothing */ -}}
+  {{- $credentials := (includeTemplate "base/helpers/load-section" (dict "root" $root "section" "ai.credentials" "required" false) | mustFromJson) -}}
+  {{-  $resolved := includeTemplate "base/ai/resolve-enabled-auth-providers" (dict "root" $root) | mustFromJson -}}
+  {{-  $allSecrets := concat ($credentials.secrets | default list) ($resolved.enabled_api_key_envs | default list) | uniq | sortAlpha -}}
+  {{-  dict "inject" list "secrets" $allSecrets "ignore" ($credentials.ignore | default list | uniq | sortAlpha) | toJson -}}
+{{- else -}}
+  {{-  $credentials := (includeTemplate "base/helpers/load-section" (dict "root" $root "section" "ai.credentials" "required" false) | mustFromJson) -}}
+  {{-  $resolved := includeTemplate "base/ai/resolve-enabled-auth-providers" (dict "root" $root) | mustFromJson -}}
+  {{-  $credInject := concat ($credentials.inject | default list) ($resolved.enabled_api_key_envs | default list) | uniq | sortAlpha -}}
+  {{-  $credIgnore := $credentials.ignore | default list | uniq | sortAlpha -}}
+  {{-  $credSecretsRaw := $credentials.secrets | default list | uniq -}}
+  {{-  $credSecrets := list -}}
+  {{-  range $s := $credSecretsRaw -}}
+  {{-    if and (not (has $s $credInject)) (not (has $s $credIgnore)) -}}
+  {{-      $credSecrets = append $credSecrets $s -}}
+  {{-    end -}}
+  {{-  end -}}
+  {{-  $credSecrets = $credSecrets | sortAlpha -}}
+  {{-  dict
+      "inject" $credInject
+      "secrets" $credSecrets
+      "ignore" $credIgnore
+  | toJson -}}
 {{- end -}}
-{{- $credSecrets = $credSecrets | sortAlpha -}}
-{{- dict
-  "inject" $credInject
-  "secrets" $credSecrets
-  "ignore" $credIgnore
-| toJson -}}

--- a/home/.chezmoitemplates/base/ai/render-greywall-fs
+++ b/home/.chezmoitemplates/base/ai/render-greywall-fs
@@ -4,6 +4,7 @@
     {{ includeTemplate "base/ai/render-greywall-fs" (dict "root" . "agent" "pi") | mustFromJson }}
   Output: JSON { allowRead, allowWrite, denyRead, denyWrite }
   Resolves path groups from ai.permissions.filesystem.paths, then appends agent-specific raw paths.
+  When agent is provided, both allow and deny lists are extended from agent sandbox.paths.
 */ -}}
 {{- $root := index . "root" -}}
 {{- $agent := dig "agent" "" . -}}
@@ -17,6 +18,8 @@
 {{-   $agentPaths := (includeTemplate "base/helpers/load-section" (dict "root" $root "section" $agentSection "required" false) | mustFromJson) -}}
 {{-   $allowRead = concat $allowRead (index $agentPaths "allow_read" | default list) | uniq | sortAlpha -}}
 {{-   $allowWrite = concat $allowWrite (index $agentPaths "allow_write" | default list) | uniq | sortAlpha -}}
+{{-   $denyRead = concat $denyRead (index $agentPaths "deny_read" | default list) | uniq | sortAlpha -}}
+{{-   $denyWrite = concat $denyWrite (index $agentPaths "deny_write" | default list) | uniq | sortAlpha -}}
 {{- end -}}
 {{- dict
   "allowRead" $allowRead

--- a/home/.chezmoitemplates/base/ai/render-omp-config
+++ b/home/.chezmoitemplates/base/ai/render-omp-config
@@ -1,0 +1,100 @@
+{{- /*
+  render-omp-config — Shared modify-template body for OMP config.yml.
+
+  Input (dict):
+    root     — chezmoi data root
+    chezmoi  — the .chezmoi context (provides stdin for modify-template)
+
+  Parses existing OMP config YAML, renders managed keys (modelRoles and
+  compaction from ai.models.tiers, static memory and settings) and merges
+  over current config. User-owned keys (theme.dark, theme.light,
+  symbolPreset, setupVersion, and future settings) are preserved via
+  mergeOverwrite.
+*/ -}}
+{{- $current := dict -}}
+{{- $rawStdin := get .chezmoi "stdin" | default "" | trim -}}
+{{- if and (not (empty $rawStdin)) (ne $rawStdin "null") -}}
+{{-   $current = fromYaml $rawStdin -}}
+{{-   if not (kindIs "map" $current) -}}{{- $current = dict -}}{{- end -}}
+{{- end -}}
+
+{{- /* ── Load tier data --- */ -}}
+{{- $tiers := includeTemplate "base/helpers/load-section" (dict "root" .root "section" "ai.models.tiers" "required" true) | mustFromJson -}}
+{{- $settings := includeTemplate "base/helpers/load-section" (dict "root" .root "section" "ai.agents.omp.settings" "required" true) | mustFromJson -}}
+{{- $defaultTier := $tiers.default | default "medium" -}}
+{{- $defaultRoute := index $tiers $defaultTier -}}
+
+{{- /* Validate default tier */ -}}
+{{- if or (not $defaultRoute) (not (kindIs "map" $defaultRoute)) -}}
+  {{- fail (printf "omp config: default tier %q missing or not a map" $defaultTier) -}}
+{{- end -}}
+{{- if not (and $defaultRoute.provider $defaultRoute.model) -}}
+  {{- fail (printf "omp config: default tier %q must have provider and model" $defaultTier) -}}
+{{- end -}}
+
+{{- /* ── Build modelRoles --- */ -}}
+{{- $fmtRef := printf "%s/%s:%s" $defaultRoute.provider $defaultRoute.model ($defaultRoute.thinking | default "high") -}}
+
+{{- $tierKeys := list "big" "oracle" "small" "medium" "visual" -}}
+{{- $tierConfigs := dict -}}
+{{- range $key := $tierKeys -}}
+{{-   $tier := get $tiers $key | default dict -}}
+{{-   $ref := "" -}}
+{{-   if $tier -}}
+{{-     if and $tier.provider $tier.model -}}
+{{-       $tThinking := $tier.thinking | default "high" -}}
+{{-       if eq $key "small" -}}
+{{-         $tThinking = $tier.thinking | default "off" -}}
+{{-       end -}}
+{{-       $ref = printf "%s/%s:%s" $tier.provider $tier.model $tThinking -}}
+{{-     else if or $tier.provider $tier.model -}}
+{{-       fail (printf "omp config: tier %q is partially specified (need provider + model)" $key) -}}
+{{-     end -}}
+{{-   end -}}
+{{-   $_ := set $tierConfigs $key $ref -}}
+{{- end -}}
+
+{{- $managed := dict
+  "modelRoles" (dict
+    "default" $fmtRef
+    "plan" ($tierConfigs.big | default $fmtRef)
+    "slow" ($tierConfigs.big | default $fmtRef)
+  )
+  "compaction" (dict
+    "enabled" true
+    "strategy" "snapcompact"
+    "reserveTokens" 16384
+    "keepRecentTokens" 20000
+  )
+  "memory" (dict
+    "backend" "local"
+  )
+  "providers" (dict
+    "webSearch" $settings.web_search
+  )
+  "theme" (dict
+    "dark" $settings.theme_dark
+    "light" $settings.theme_light
+  )
+  "symbolPreset" $settings.symbol_preset
+-}}
+
+{{- /* Add optional roles */ -}}
+{{- if $tierConfigs.oracle -}}{{- $_ := set $managed.modelRoles "advisor" $tierConfigs.oracle -}}{{- end -}}
+{{- if $tierConfigs.small -}}
+{{-   $_ := set $managed.modelRoles "smol" $tierConfigs.small -}}
+{{-   $_ := set $managed.modelRoles "tiny" $tierConfigs.small -}}
+{{- end -}}
+{{- if $tierConfigs.medium -}}
+{{-   $_ := set $managed.modelRoles "task" $tierConfigs.medium -}}
+{{-   $_ := set $managed.modelRoles "commit" $tierConfigs.medium -}}
+{{- end -}}
+{{- if $tierConfigs.visual -}}
+{{-   $_ := set $managed.modelRoles "designer" $tierConfigs.visual -}}
+{{-   $_ := set $managed.modelRoles "vision" $tierConfigs.visual -}}
+{{- end -}}
+
+{{- /* Merge: managed overrides current config, user-owned keys preserved */ -}}
+{{- $final := mergeOverwrite $current $managed -}}
+
+{{- toYaml $final -}}

--- a/home/private_dot_config/exact_greywall/.chezmoiignore
+++ b/home/private_dot_config/exact_greywall/.chezmoiignore
@@ -1,3 +1,4 @@
 learned/*
 !learned/pi.json
 !learned/opencode.json
+!learned/omp.json

--- a/home/private_dot_config/exact_greywall/learned/modify_omp.json
+++ b/home/private_dot_config/exact_greywall/learned/modify_omp.json
@@ -1,0 +1,6 @@
+{{- /* chezmoi:modify-template */ -}}
+{{- /* Modify template for learned OMP Greywall profile.
+  Preserve Greywall learned/bundled baseline so profile drift checks stay stable.
+  Append OMP overlays and shared credentials deterministically. */ -}}
+{{- $rawStdin := get .chezmoi "stdin" | default "" | trim -}}
+{{- includeTemplate "base/ai/merge-greywall-learned-profile" (dict "root" . "agent" "omp" "stdin" $rawStdin) -}}

--- a/home/private_dot_config/exact_private_omp/.chezmoiignore
+++ b/home/private_dot_config/exact_private_omp/.chezmoiignore
@@ -1,0 +1,32 @@
+# OMP runtime databases and native/cache state
+*.db*
+gpu_cache.json
+last-changelog-version
+terminal-sessions/
+terminal-sessions/**
+
+# Runtime directories
+sessions/
+sessions/**
+blobs/
+blobs/**
+memory/
+memory/**
+logs/
+logs/**
+cache/
+cache/**
+natives/
+natives/**
+plugins/
+plugins/**
+extensions/
+extensions/**
+
+# Runtime metadata
+.mcp.json
+trust.json
+state.json
+mcp-cache.json
+.caveman-active
+.lock

--- a/home/private_dot_config/exact_private_omp/modify_config.yml
+++ b/home/private_dot_config/exact_private_omp/modify_config.yml
@@ -1,0 +1,5 @@
+{{- /* chezmoi:modify-template */ -}}
+{{- /* OMP config — managed modelRoles/compaction merged from tier data.
+  User-owned keys (theme, symbolPreset, setupVersion, etc.) are preserved.
+  Managed sections are overwritten on next apply. Do not edit modelRoles or compaction. */ -}}
+{{- includeTemplate "base/ai/render-omp-config" (dict "root" . "chezmoi" .chezmoi) -}}

--- a/home/private_dot_config/exact_private_omp/private_security.yml.tmpl
+++ b/home/private_dot_config/exact_private_omp/private_security.yml.tmpl
@@ -1,0 +1,43 @@
+# Managed security overlay for OMP — rendered from layered data.
+# Injected via --config after user args; overrides user-facing config.
+# Do not edit directly.
+{{- $s := includeTemplate "base/helpers/load-section" (dict "root" . "section" "ai.agents.omp.security" "required" true) | mustFromJson }}
+tools:
+  approvalMode: {{ $s.tools.approval_mode }}
+  discoveryMode: {{ $s.tools.discovery_mode }}
+
+mcp:
+  enableProjectConfig: {{ $s.mcp.enable_project_config }}
+  discoveryMode: {{ $s.mcp.discovery_mode }}
+
+task:
+  isolation:
+    mode: {{ $s.task.isolation.mode }}
+  maxConcurrency: {{ $s.task.max_concurrency }}
+  maxRecursionDepth: {{ $s.task.max_recursion_depth }}
+
+skills:
+  enabled: {{ $s.skills.enabled }}
+  enableSkillCommands: {{ $s.skills.enable_skill_commands }}
+  enableCodexUser: {{ $s.skills.enable_codex_user }}
+  enableClaudeUser: {{ $s.skills.enable_claude_user }}
+  enableClaudeProject: {{ $s.skills.enable_claude_project }}
+  enablePiUser: {{ $s.skills.enable_pi_user }}
+  enablePiProject: {{ $s.skills.enable_pi_project }}
+  enableAgentsUser: {{ $s.skills.enable_agents_user }}
+  enableAgentsProject: {{ $s.skills.enable_agents_project }}
+
+commands:
+  enableClaudeUser: {{ $s.commands.enable_claude_user }}
+  enableClaudeProject: {{ $s.commands.enable_claude_project }}
+  enableOpencodeUser: {{ $s.commands.enable_opencode_user }}
+  enableOpencodeProject: {{ $s.commands.enable_opencode_project }}
+
+disabledProviders:
+{{- range $s.disabled_providers }}
+  - {{ . }}
+{{- end }}
+
+startup:
+  checkUpdate: {{ $s.startup.check_update }}
+  setupWizard: {{ $s.startup.setup_wizard }}

--- a/home/private_dot_config/exact_private_omp/symlink_AGENTS.md.tmpl
+++ b/home/private_dot_config/exact_private_omp/symlink_AGENTS.md.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/agents/AGENTS.md

--- a/home/private_dot_local/exact_bin/executable_agent-launch.tmpl
+++ b/home/private_dot_local/exact_bin/executable_agent-launch.tmpl
@@ -19,8 +19,14 @@ case "$SELF" in
     GREYWALL_PROFILE="opencode"
     CONFIG_SUBDIR="opencode"
     ;;
+  omp-agent)
+    AGENT_NAME="omp"
+    BINARY_NAME="omp"
+    GREYWALL_PROFILE="omp"
+    CONFIG_SUBDIR="omp"
+    ;;
   agent-launch)
-    printf 'Error: call via a symlink (pi-agent, opencode-agent), not directly.\n' >&2
+    printf 'Error: call via a symlink (pi-agent, opencode-agent, omp-agent), not directly.\n' >&2
     exit 1
     ;;
   *)
@@ -72,6 +78,11 @@ profile_dir() {
         *)            die "Unknown profile: $1" ;;
       esac
       ;;
+    omp)
+      # OMP uses PI_CODING_AGENT_DIR as the single config root (no named profile).
+      # Config is canonical at $HOME/.config/omp (not XDG-relative).
+      printf '%s\n' "$HOME/.config/omp"
+      ;;
   esac
 }
 
@@ -97,10 +108,19 @@ print_env() {
         printf 'export OPENCODE_PORT="%s"\n' "${OPENCODE_PORT:-$(pick_high_port)}"
       fi
       ;;
+    omp)
+      printf "# OMP env — canonical config root, no named profile\n"
+      printf "# Scrub inherited Pi, OpenCode, and OMP vars\n"
+      printf "for __v in \$(env | awk -F= '/^(PI_|OPENCODE_)/ { print \$1 }'); do unset \"\$__v\"; done 2>/dev/null || :\n"
+      printf "unset OMP_PROFILE\n"
+      printf 'export PI_CODING_AGENT_DIR="%s"\n' "$HOME/.config/omp"
+      ;;
   esac
-  printf 'export ENGRAM_DATA_DIR="%s"\n' "${ENGRAM_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/engram}"
-  printf 'export ENGRAM_PORT="%s"\n' "${ENGRAM_PORT:-7437}"
-  printf 'export ENGRAM_URL="http://127.0.0.1:%s"\n' "${ENGRAM_PORT:-7437}"
+  if [ "$AGENT_NAME" != "omp" ]; then
+    printf 'export ENGRAM_DATA_DIR="%s"\n' "${ENGRAM_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/engram}"
+    printf 'export ENGRAM_PORT="%s"\n' "${ENGRAM_PORT:-7437}"
+    printf 'export ENGRAM_URL="http://127.0.0.1:%s"\n' "${ENGRAM_PORT:-7437}"
+  fi
 }
 
 # ── Agent-specific: preflight update ──
@@ -141,6 +161,11 @@ preflight_update() {
         ok "Dependencies: cached"
       fi
       ;;
+    omp)
+      # OMP is a standalone compiled binary; no preflight needed.
+      # Extensions disabled via config and --no-extensions flag.
+      ok "Binary: standalone (no preflight needed)"
+      ;;
   esac
 }
 
@@ -165,6 +190,16 @@ set_runtime_env() {
         dim "Background subagents: enabled"
         dim "OpenCode port: $OPENCODE_PORT"
       fi
+      dim "Config:  $dir"
+      ;;
+    omp)
+      # Scrub all inherited vars that could redirect OMP to Pi/OpenCode state
+      for _v in $(env | awk -F= '/^(PI_|OPENCODE_)/ { print $1 }'); do
+        unset "$_v"
+      done
+      unset OMP_PROFILE
+      # Canonical OMP config root at $HOME/.config/omp
+      export PI_CODING_AGENT_DIR="$dir"
       dim "Config:  $dir"
       ;;
   esac
@@ -221,13 +256,47 @@ Commands:
   --print-env [prof]  print env vars for profile
 EOF
       ;;
+    omp)
+      cat <<'EOF'
+Usage: omp-agent [omp args...]
+       omp-agent --print-env [profile]
+       omp-agent --help
+
+Configuration:
+  Managed config root at $HOME/.config/omp (canonical, not XDG-relative).
+  PI_CODING_AGENT_DIR is set to this root; no named profile is active.
+  --profile, --alias, and Pi profile names are rejected.
+  Sandbox via greywall is mandatory — no --no-greywall bypass.
+
+Safety:
+  Scrubs inherited PI_*, OPENCODE_*, and OMP_PROFILE env vars.
+  Sets only PI_CODING_AGENT_DIR for OMP.
+  Injects managed --config <security.yml> and --no-extensions with precedence.
+  Rejects extension/plugin injection flags and management subcommands.
+  Fails closed: requires readable $HOME/.config/omp/security.yml.
+
+Args:
+  omp args            forwarded to omp
+
+Commands:
+  --print-env [prof]  print env vars for the config root
+  --help              this message
+EOF
+      ;;
   esac
   exit 0
 }
 
 # ── Shared: profile list ──
 list_profiles() {
-  printf '%s\n' core factory minimal
+  case "$AGENT_NAME" in
+    omp)
+      printf 'OMP uses a single configuration root (no named profiles).\n'
+      ;;
+    *)
+      printf '%s\n' core factory minimal
+      ;;
+  esac
 }
 
 # ── Shared: PWD guard ──
@@ -357,17 +426,71 @@ esac
 # ── Dispatch: option parsing ──
 no_greywall=false
 no_update=false
-profile="core"
+if [ "$AGENT_NAME" = "omp" ]; then
+  profile="default"
+else
+  profile="core"
+fi
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --) shift; break ;;
-    --no-greywall) no_greywall=true; shift ;;
+    --no-greywall)
+      if [ "$AGENT_NAME" = "omp" ]; then
+        die "OMP: --no-greywall rejected (sandbox is mandatory)"
+      fi
+      no_greywall=true; shift ;;
     --no-update) no_update=true; shift ;;
-    core|default|factory|minimal) profile="$1"; shift ;;
+    core|default|factory|minimal)
+      if [ "$AGENT_NAME" = "omp" ]; then
+        die "OMP: profile '$1' rejected (single config root, no named profiles)"
+      fi
+      profile="$1"
+      shift
+      ;;
     *) break ;;
   esac
 done
+
+# OMP: reject unsafe overrides, management subcommands, enforce single config root
+if [ "$AGENT_NAME" = "omp" ]; then
+  # Reject CLI overrides in remaining args
+  for _arg do
+    case "$_arg" in
+      --profile|--profile=*)
+        die "OMP: --profile rejected (single config root, no named profiles)" ;;
+      --yolo|--auto-approve|--plan-yolo)
+        die "OMP: unsafe approval flag '$_arg' rejected" ;;
+      --config|--config=*)
+        die "OMP: --config overlay rejected (config is managed)" ;;
+      --approval-mode|--approval-mode=*)
+        die "OMP: --approval-mode override rejected" ;;
+      --api-key|--api-key=*)
+        die "OMP: --api-key rejected (use interactive authentication)" ;;
+      --alias|--alias=*)
+        die "OMP: --alias requires --profile; both rejected" ;;
+      -e|--extension|--extension=*)
+        die "OMP: extension injection flag '$_arg' rejected (extensions managed via security.yml)" ;;
+      --hook|--hook=*)
+        die "OMP: hook injection flag '$_arg' rejected (hooks managed via security.yml)" ;;
+      --plugin-dir|--plugin-dir=*)
+        die "OMP: plugin dir flag '$_arg' rejected (plugins managed via security.yml)" ;;
+    esac
+  done
+  unset _arg
+
+  # Reject management subcommands that cannot safely receive injected --config/--no-extensions
+  for _cmd do
+    case "$_cmd" in
+      init|setup|install|completion|doctor|update|manage|system|migrate|reset|uninstall)
+        die "OMP: management subcommand '$_cmd' rejected (use binary directly, not omp-agent)" ;;
+    esac
+    break  # only check first positional arg
+  done
+  unset _cmd
+
+  profile="default"
+fi
 
 # Factory OpenCode: keep --port and OPENCODE_PORT aligned for oh-my-opencode-slim
 if [ "$AGENT_NAME" = "opencode" ] && [ "$profile" = "factory" ]; then
@@ -397,6 +520,18 @@ if [ "$AGENT_NAME" = "opencode" ] && [ "$profile" = "factory" ]; then
   fi
   unset _port _next_is_port _arg
 fi
+
+# OMP: inject managed flags with precedence; fail closed on missing security
+if [ "$AGENT_NAME" = "omp" ]; then
+  _omp_security="$HOME/.config/omp/security.yml"
+  if [ ! -r "$_omp_security" ]; then
+    die "OMP: required security config not found or not readable: $_omp_security"
+  fi
+  # Inject managed flags after remaining user args so they take precedence
+  set -- "$@" --no-extensions --config "$_omp_security"
+  unset _omp_security
+fi
+
 # ── Launch ──
 pwd_guard
 
@@ -414,13 +549,13 @@ if [ "$no_greywall" = true ]; then
   exec "$BINARY_NAME" "$@"
 fi
 
-dim "Launch: greywall --profile $GREYWALL_PROFILE -- $BINARY_NAME ..."
-
 # Engram daemon must start before proxy env is set — its curl health-check
 # must reach localhost directly, not through the (not-yet-running) greyproxy.
-ensure_engram
-
-export PLANNOTATOR_REMOTE=1
+# OMP uses its own hindsight memory; skip shared Engram.
+if [ "$AGENT_NAME" != "omp" ]; then
+  ensure_engram
+  export PLANNOTATOR_REMOTE=1
+fi
 
 # ── Proxy / CA env (force all agent traffic through Greyproxy) ──
 export HTTP_PROXY="http://127.0.0.1:43051"
@@ -439,4 +574,5 @@ unset _CA
 
 ensure_greyproxy
 
+dim "Launch: greywall --profile $GREYWALL_PROFILE -- $BINARY_NAME ..."
 exec greywall --profile "$GREYWALL_PROFILE" -- "$BINARY_NAME" "$@"

--- a/home/private_dot_local/exact_bin/symlink_omp-agent.tmpl
+++ b/home/private_dot_local/exact_bin/symlink_omp-agent.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.local/bin/agent-launch

--- a/home/private_dot_local/share/exact_dotfiles/exact_test/executable_check-dotfiles.sh
+++ b/home/private_dot_local/share/exact_dotfiles/exact_test/executable_check-dotfiles.sh
@@ -18,7 +18,7 @@ fi
 # ----- Constants & defaults ---------------------------------------------------
 
 PACKAGE_SUITES=(test-system-packages.bats test-mise-packages.bats test-helm-plugins.bats test-krew-plugins.bats)
-AI_SUITES=(test-ai-shared.bats test-ai-pi.bats test-ai-opencode.bats test-ai-local-llm.bats test-ai-permissions.bats)
+AI_SUITES=(test-ai-shared.bats test-ai-pi.bats test-ai-opencode.bats test-ai-omp.bats test-ai-local-llm.bats test-ai-permissions.bats)
 ALL_SUITES=("${PACKAGE_SUITES[@]}" test-config.bats "${AI_SUITES[@]}")
 
 detectJobs() {
@@ -55,6 +55,7 @@ suiteAlias() {
   ai-shared) echo test-ai-shared.bats ;;
   ai-pi) echo test-ai-pi.bats ;;
   ai-opencode) echo test-ai-opencode.bats ;;
+  ai-omp) echo test-ai-omp.bats ;;
   ai-local-llm | ai-llm) echo test-ai-local-llm.bats ;;
   ai-permissions | ai-perms) echo test-ai-permissions.bats ;;
   all) printf '%s\n' "${ALL_SUITES[@]}" ;;

--- a/home/private_dot_local/share/exact_dotfiles/exact_test/test-ai-omp.bats.tmpl
+++ b/home/private_dot_local/share/exact_dotfiles/exact_test/test-ai-omp.bats.tmpl
@@ -1,0 +1,375 @@
+#!/usr/bin/env bats
+
+# bats file_tags=suite:ai
+
+load 'common-helper'
+
+setup() {
+  common_setup
+  AGENTS_MD="${HOME}/.config/agents/AGENTS.md"
+  OMP_DIR="$HOME/.config/omp"
+  SECURITY_FILE="$OMP_DIR/security.yml"
+  GREYWALL_FILE="$HOME/.config/greywall/learned/omp.json"
+}
+
+{{- if (get .toolchains "omp" | default false) }}
+
+{{- $tiers := includeTemplate "base/helpers/load-section" (dict "root" . "section" "ai.models.tiers" "required" true) | mustFromJson }}
+{{- $creds := includeTemplate "base/ai/render-credentials" . | mustFromJson }}
+{{- $ompCreds := includeTemplate "base/ai/render-credentials" (dict "root" . "agent" "omp") | mustFromJson }}
+
+# ── Helpers ──
+
+# assert_yq EXPR FILE — compact yq -e + assert_success
+assert_yq() { run yq -e "$1" "$2"; assert_success; }
+
+# assert_jq EXPR FILE — compact jq -e + assert_success for JSON artifacts
+assert_jq() { run jq -e "$1" "$2"; assert_success; }
+
+# assert_rejected ARGS... — launcher must reject a managed-boundary override
+assert_rejected() {
+  run "$HOME/.local/bin/omp-agent" "$@"
+  assert_failure
+  assert_output --partial "rejected"
+}
+
+# setup_mock_bins DIR — create curl/nc/greyproxy stubs for dispatch tests
+setup_mock_bins() {
+  local d="$1"
+  cat > "$d/curl" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+  cat > "$d/nc" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+  cat > "$d/greyproxy" <<'EOF'
+#!/usr/bin/env sh
+echo "greyproxy 1.0.0"
+EOF
+  chmod +x "$d/curl" "$d/nc" "$d/greyproxy"
+}
+
+# make_test_home — isolated HOME with the managed security overlay present
+make_test_home() {
+  local d
+  d="$(mktemp -d "$BATS_TEST_TMPDIR/home.XXXXXX")"
+  mkdir -p "$d/.config/omp"
+  touch "$d/.config/omp/security.yml"
+  printf '%s\n' "$d"
+}
+
+# ── Package / Pin ──
+
+# bats test_tags=toolchain:omp,kind:package
+@test "omp binary is installed at pinned version 16.4.8" {
+  run mise ls github:can1357/oh-my-pi 2>/dev/null
+  assert_success
+  assert_output --partial "16.4.8"
+  run omp --version
+  assert_success
+  assert_output --regexp "16\.4\.8"
+}
+
+# bats test_tags=toolchain:omp,kind:package
+@test "omp binary is on PATH" {
+  run command -v omp
+  assert_success
+}
+
+# ── Symlinks ──
+
+# bats test_tags=toolchain:omp,kind:symlink
+@test "omp-agent symlink resolves to agent-launch and is executable" {
+  run readlink -f "$HOME/.local/bin/omp-agent"
+  assert_success
+  assert_output "$HOME/.local/bin/agent-launch"
+  assert_file_executable "$HOME/.local/bin/omp-agent"
+}
+
+# bats test_tags=toolchain:omp,kind:symlink
+@test "omp AGENTS.md fans out to global AGENTS.md" {
+  run readlink -f "$OMP_DIR/AGENTS.md"
+  assert_success
+  assert_output "$AGENTS_MD"
+}
+
+# bats test_tags=toolchain:omp,kind:symlink
+@test "omp legacy root symlink resolves to XDG root" {
+  run readlink -f "$HOME/.omp"
+  assert_success
+  assert_output "$OMP_DIR"
+}
+
+# ── Launcher boundaries ──
+
+# bats test_tags=toolchain:omp,kind:launcher
+@test "omp-agent management flags show greywall and single config root" {
+  run "$HOME/.local/bin/omp-agent" --help
+  assert_success
+  assert_output --partial "greywall"
+  assert_output --partial ".config/omp"
+  run "$HOME/.local/bin/omp-agent" --help --no-greywall
+  assert_success
+  assert_output --partial "greywall"
+  run "$HOME/.local/bin/omp-agent" --list --no-greywall
+  assert_success
+}
+
+# bats test_tags=toolchain:omp,kind:launcher
+@test "omp-agent rejects unsafe overrides and positional profile names" {
+  run "$HOME/.local/bin/omp-agent" --no-greywall
+  assert_failure
+  assert_rejected --profile work
+  assert_rejected --yolo
+  assert_rejected --auto-approve
+  assert_rejected --plan-yolo
+  assert_rejected --approval-mode yolo
+  assert_rejected --config /tmp/evil.yaml
+  assert_rejected --api-key sk-abc
+  assert_rejected --alias work
+  assert_rejected core
+  assert_rejected factory
+  assert_rejected minimal
+}
+
+# bats test_tags=toolchain:omp,kind:launcher
+@test "omp-agent --print-env scrubs injected vars and does not leak OMP_PROFILE" {
+  run env PI_CODING_AGENT_DIR=/evil PI_CODING_AGENT_SESSION_DIR=/evil PI_PROFILE=evil \
+    PI_ARBITRARY=should-scrub \
+    OPENCODE_CONFIG=/evil OPENCODE_PORT=/evil \
+    OMP_PROFILE=should-not-appear \
+    "$HOME/.local/bin/omp-agent" --print-env
+  assert_success
+  assert_output --partial "for __v in"
+  assert_output --partial "unset OMP_PROFILE"
+  assert_output --partial "PI_CODING_AGENT_DIR="
+  refute_output --partial "OMP_PROFILE="
+}
+
+# ── Config YAML ──
+
+# bats test_tags=toolchain:omp,kind:config
+@test "omp config.yml has declarative routing, appearance, and compaction settings" {
+  assert_yq 'has("modelRoles") and has("compaction") and has("memory") and .memory.backend == "local" and .theme.dark == "dark-catppuccin" and .theme.light == "light-catppuccin" and .symbolPreset == "nerd" and .providers.webSearch == "auto" and (has("tools") | not) and (has("mcp") | not) and (has("task") | not) and (has("skills") | not)' "$OMP_DIR/config.yml"
+  assert_yq '.compaction.enabled == true' "$OMP_DIR/config.yml"
+  assert_yq '.compaction.strategy == "snapcompact"' "$OMP_DIR/config.yml"
+  assert_yq '.compaction.reserveTokens == 16384' "$OMP_DIR/config.yml"
+  assert_yq '.compaction.keepRecentTokens == 20000' "$OMP_DIR/config.yml"
+}
+
+# ── Model roles ──
+
+# bats test_tags=toolchain:omp,kind:model,tier:routing
+@test "omp config.yml has provider-qualified modelRoles for all tiers" {
+  for role in default plan slow advisor smol tiny task commit; do
+    run yq -e ".modelRoles | has(\"${role}\")" "$OMP_DIR/config.yml"
+    assert_success "missing role: $role"
+    run yq -r ".modelRoles.${role}" "$OMP_DIR/config.yml"
+    assert_success
+    [ -n "$output" ]
+    case "$output" in
+      */*:*) ;;
+      *) false ;;
+    esac
+  done
+}
+
+# ── Security overlay ──
+
+# bats test_tags=toolchain:omp,kind:config
+@test "omp security.yml exists with approval mode, discovery auto, and task isolation" {
+  assert_file_exists "$SECURITY_FILE"
+  assert_yq '.tools.approvalMode == "yolo" and .tools.discoveryMode == "auto"' "$SECURITY_FILE"
+  assert_yq '.task.isolation.mode == "auto"' "$SECURITY_FILE"
+  assert_yq '.task.maxConcurrency == 4' "$SECURITY_FILE"
+}
+
+# bats test_tags=toolchain:omp,kind:config
+@test "omp security.yml enables local skills and disables cross-agent sources" {
+  assert_yq '.skills.enabled == true and .skills.enableSkillCommands == true and (.skills.enablePiUser == false) and (.skills.enablePiProject == false) and (.skills.enableAgentsUser == false) and (.skills.enableAgentsProject == false) and (.commands.enableClaudeUser == false) and (.commands.enableOpencodeUser == false)' "$SECURITY_FILE"
+}
+
+# bats test_tags=toolchain:omp,kind:config
+@test "omp security.yml configures MCP, startup, and disabledProviders per profile" {
+  assert_yq '.mcp.enableProjectConfig == false and .mcp.discoveryMode == true and (.disabledProviders | type == "!!seq")' "$SECURITY_FILE"
+  assert_yq '.disabledProviders | length > 0' "$SECURITY_FILE"
+  assert_yq '.startup.checkUpdate == false and .startup.setupWizard == false' "$SECURITY_FILE"
+{{- if eq .host.profile "personal" }}
+  assert_yq '(.disabledProviders | map(select(. == "openai-codex")) | length == 0) and (.disabledProviders | map(select(. == "opencode-go")) | length == 0) and (.disabledProviders | map(select(. == "openrouter")) | length == 0)' "$SECURITY_FILE"
+{{- end }}
+{{- if eq .host.profile "work" }}
+  assert_yq '(.disabledProviders | map(select(. == "github-copilot")) | length == 0) and (.disabledProviders | map(select(. == "openai-codex")) | length == 1) and (.disabledProviders | map(select(. == "opencode-go")) | length == 1) and (.disabledProviders | map(select(. == "openrouter")) | length == 1)' "$SECURITY_FILE"
+{{- end }}
+}
+
+# ── Greywall learned profile ──
+
+# bats test_tags=toolchain:omp,kind:greywall
+@test "omp greywall profile exists with valid schema" {
+  assert_file_exists "$GREYWALL_FILE"
+  assert_jq '.schemaVersion == 1' "$GREYWALL_FILE"
+}
+
+# bats test_tags=toolchain:omp,kind:greywall
+@test "omp greywall enforces allow-read and deny-write for OMP paths" {
+  assert_file_exists "$GREYWALL_FILE"
+  assert_jq '.filesystem.allowRead | index("~/.config/omp/**") != null' "$GREYWALL_FILE"
+  assert_jq '(.filesystem.allowRead | index("~/.config/pi/**") | not)' "$GREYWALL_FILE"
+  assert_jq '(.filesystem.allowRead | index("~/.config/opencode/**") | not)' "$GREYWALL_FILE"
+  # OMP root is not deny-written (managed overlay)
+  assert_jq '.filesystem.denyWrite | index("~/.config/omp/**") == null' "$GREYWALL_FILE"
+  # config.yml is allow-writable (modify-managed)
+  assert_jq '(.filesystem.allowWrite | index("~/.config/omp/config.yml") != null) or (.filesystem.allowWrite | index("~/.config/omp/**") != null)' "$GREYWALL_FILE"
+  assert_jq '.filesystem.denyWrite | index("~/.config/omp/config.yml") | not' "$GREYWALL_FILE"
+  # security.yml is deny-write (enforced overlay)
+  assert_jq '.filesystem.denyWrite | index("~/.config/omp/security.yml") != null' "$GREYWALL_FILE"
+}
+
+# bats test_tags=toolchain:omp,kind:greywall
+@test "omp greywall credentials and network include secrets, sockets, and ports" {
+  assert_file_exists "$GREYWALL_FILE"
+  assert_jq '.credentials.inject == []' "$GREYWALL_FILE"
+  assert_jq '.credentials.secrets | length > 0' "$GREYWALL_FILE"
+  assert_jq '.network.allowUnixSockets | index("~/.local/share/tmux") != null' "$GREYWALL_FILE"
+  assert_jq '(.network.forwardPorts // []) | index(7437) != null' "$GREYWALL_FILE"
+}
+
+# ── Credentials renderer ──
+
+# bats test_tags=toolchain:omp,kind:credentials
+@test "global and omp credentials render correctly" {
+  {{- $g := $creds }}
+  run jq -e 'has("inject") and has("secrets") and has("ignore")' <<< '{{ $g | toJson }}'
+  assert_success
+  run jq -e '.ignore | length > 0' <<< '{{ $g | toJson }}'
+  assert_success
+  {{- $c := $ompCreds }}
+  run jq -e '.inject == []' <<< '{{ $c | toJson }}'
+  assert_success
+  run jq -e '.secrets | length > 0' <<< '{{ $c | toJson }}'
+  assert_success
+}
+
+# ── Isolation / Auth ──
+
+# bats test_tags=toolchain:omp,kind:isolation
+@test "omp config root does not overlap Pi/OpenCode and does not manage auth files" {
+  assert [ "$OMP_DIR" != "$HOME/.config/pi" ]
+  assert [ "$OMP_DIR" != "$HOME/.config/opencode" ]
+  assert [ ! -f "$OMP_DIR/keys.yaml" ]
+  assert [ ! -f "$OMP_DIR/auth.json" ]
+}
+
+# ── Agent launcher script ──
+
+# bats test_tags=toolchain:omp,kind:launcher
+@test "omp-agent agent-launch script dispatches via greywall --profile omp" {
+  run grep -F 'greywall --profile "$GREYWALL_PROFILE"' "$HOME/.local/bin/agent-launch"
+  assert_success
+  run grep -F 'AGENT_NAME="omp"' "$HOME/.local/bin/agent-launch"
+  assert_success
+  run grep -F 'BINARY_NAME="omp"' "$HOME/.local/bin/agent-launch"
+  assert_success
+}
+
+# ── Full dispatch ──
+
+# bats test_tags=toolchain:omp,kind:launcher
+@test "omp-agent full dispatch: greywall --profile omp with --no-extensions and --config" {
+  local mockdir
+  local test_home
+  mockdir="$(mktemp -d "$BATS_TEST_TMPDIR/mock.XXXXXX")"
+  test_home="$(make_test_home)"
+  setup_mock_bins "$mockdir"
+
+  cat >"$mockdir/greywall" <<'SCRIPT'
+#!/usr/bin/env sh
+echo "GREYWALL_CALLED=true"
+echo "GREYWALL_PROFILE=$2"
+shift 3
+[ "${1:-}" = "--" ] && shift
+echo "OMP_PATH=$1"
+shift
+echo "OMP_ARGS=$*"
+exit 0
+SCRIPT
+
+  cat >"$mockdir/omp" <<'SCRIPT'
+#!/usr/bin/env sh
+echo "OMP_RECEIVED_ARGS=$*"
+SCRIPT
+  chmod +x "$mockdir/greywall" "$mockdir/omp"
+
+  run env PATH="$mockdir:$PATH" XDG_CONFIG_HOME="$test_home/.config" HOME="$test_home" \
+    "$HOME/.local/bin/omp-agent" -c session-abc
+  assert_success
+  assert_output --partial "GREYWALL_CALLED=true"
+  assert_output --partial "GREYWALL_PROFILE=omp"
+  assert_output --partial "--no-extensions"
+  assert_output --partial "security.yml"
+  assert_output --partial "session-abc"
+}
+
+# bats test_tags=toolchain:omp,kind:launcher
+@test "omp-agent full dispatch: missing security overlay fails closed" {
+  local mockdir
+  local test_home
+  mockdir="$(mktemp -d "$BATS_TEST_TMPDIR/mock.XXXXXX")"
+  test_home="$(mktemp -d "$BATS_TEST_TMPDIR/home.XXXXXX")"
+  setup_mock_bins "$mockdir"
+
+  cat >"$mockdir/greywall" <<'SCRIPT'
+#!/usr/bin/env sh
+shift 2
+[ "${1:-}" = "--" ] && shift
+exec "$@"
+SCRIPT
+
+  cat >"$mockdir/omp" <<'SCRIPT'
+#!/usr/bin/env sh
+echo "OMP_RECEIVED_ARGS=$*"
+SCRIPT
+  chmod +x "$mockdir/greywall" "$mockdir/omp"
+
+  run env PATH="$mockdir:$PATH" XDG_CONFIG_HOME="$test_home/.config" HOME="$test_home" \
+    "$HOME/.local/bin/omp-agent" -c session-abc
+  assert_failure
+}
+
+# bats test_tags=toolchain:omp,kind:launcher
+@test "omp-agent full dispatch: env isolation scrubs injected PI_* and OPENCODE_*" {
+  local mockdir
+  local test_home
+  mockdir="$(mktemp -d "$BATS_TEST_TMPDIR/mock.XXXXXX")"
+  test_home="$(make_test_home)"
+  setup_mock_bins "$mockdir"
+
+  cat >"$mockdir/greywall" <<'SCRIPT'
+#!/usr/bin/env sh
+shift 2
+[ "${1:-}" = "--" ] && shift
+exec "$@"
+SCRIPT
+
+  cat >"$mockdir/omp" <<'SCRIPT'
+#!/usr/bin/env sh
+echo "PI_ARBITRARY=[${PI_ARBITRARY:-unset}]"
+echo "OPENCODE_CONFIG=[${OPENCODE_CONFIG:-unset}]"
+echo "OPENCODE_PORT=[${OPENCODE_PORT:-unset}]"
+SCRIPT
+  chmod +x "$mockdir/greywall" "$mockdir/omp"
+
+  run env PATH="$mockdir:$PATH" PI_CODING_AGENT_DIR=/leak PI_ARBITRARY=bad \
+    OPENCODE_CONFIG=/leak OPENCODE_PORT=9999 \
+    XDG_CONFIG_HOME="$test_home/.config" HOME="$test_home" \
+    "$HOME/.local/bin/omp-agent" -c session-abc
+  assert_success
+  assert_output --partial "PI_ARBITRARY=[unset]"
+  assert_output --partial "OPENCODE_CONFIG=[unset]"
+  assert_output --partial "OPENCODE_PORT=[unset]"
+  refute_output --partial "PI_CODING_AGENT_DIR=/leak"
+}
+
+{{- end }}

--- a/home/symlink_dot_omp.tmpl
+++ b/home/symlink_dot_omp.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/omp


### PR DESCRIPTION
- Add omp agent data config (network/permissions/packages)
- Register omp in agent list and emoji map
- Wire omp into agent-launch dispatcher, render-omp-config template
- Add per-profile provider restrictions (personal/work)
- Update merge-greywall-learned-profile with deny-read/write and omp cleanup
- Make render-credentials agent-aware for credential isolation
- Extend render-greywall-fs to apply agent sandbox paths
- Add greywall learned profile for omp
- Fix chezmoiignore template to use get() and add omp gate
- Document omp in README
- Pre-commit: exclude modify_* yaml files from prettier/taplo hooks
