### PR TITLE
refactor(ai): consolidate provider catalog, rolling library tags, default-all filtering, and direct skill paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Prebuilt images are also published to GHCR and Docker Hub:
   `--no-update` to skip the dependency cache preflight).
   Runtime profiles: `opencode-agent` or `opencode-agent core` for the daily driver
   with context pruning and notification plugins, `opencode-agent minimal` for a
-  lightweight stack (no plugins, no subagents), and `opencode-agent factory` for
-  slim multi-agent orchestration with background subagents, worktrees, and planning.
+  lightweight stack (no subagents; includes local utility plugins), and
+  `opencode-agent factory` for slim multi-agent orchestration with background
+  subagents, worktrees, and planning.
   Core uses the default OpenCode config location; factory uses a profile overlay
   (`~/.config/opencode/profiles/factory/`). Every profile also exposes the local
   LLM gateway (configured under `[ai.profile.<profile>.models.catalog.local]`)
@@ -84,6 +85,18 @@ Prebuilt images are also published to GHCR and Docker Hub:
   focus events, CSI-u extended keys, and OSC-52 passthrough for OpenCode/Pi.
   Plugins: `tmux-yank` (WSL2 clipboard fallback), `tmux-resurrect`,
   `tmux-continuum` (save-only, no auto-restore), `tmux-open`.
+
+  All profiles include `@slkiser/opencode-quota` (latest; follows OpenCode
+  plugin auto-update resolution). Shared quota settings live in the default
+  OpenCode config and are symlinked into core/factory. Personal monitors
+  OpenAI/Codex and OpenCode Go; work monitors GitHub Copilot. Toasts are off;
+  sidebar and compact status are on. No system-prompt injection.
+  Prerequisites: Node >=20, OpenCode >=1.4.3.
+
+  OMO model fallback chains are optional, remote-only (no `provider=local`).
+  Personal profile configures cross-provider chains (OpenAI Codex ↔ OpenCode
+  Go). Work profile is primary-only (GitHub Copilot strings, no fallback
+  arrays).
 
 ### Local LLM serving
 

--- a/home/.chezmoidata/base/ai/agents/omp.toml
+++ b/home/.chezmoidata/base/ai/agents/omp.toml
@@ -47,16 +47,6 @@ deny_write = [
   "~/.config/omp/security.yml"
 ]
 
-[ai.base.agents.omp.security]
-disabled_providers = [
-  "claude",
-  "gemini",
-  "github-copilot",
-  "openai-codex",
-  "opencode-go",
-  "openrouter"
-]
-
 [ai.base.agents.omp.security.commands]
 enable_claude_user = false
 enable_claude_project = false
@@ -98,3 +88,4 @@ theme_dark = "dark-catppuccin"
 theme_light = "light-catppuccin"
 symbol_preset = "nerd"
 web_search = "auto"
+providers = ["azure", "openai-codex", "anthropic", "zai", "kimi-code", "openrouter", "github-copilot", "cursor", "devin", "google-antigravity", "google-gemini-cli", "openai-codex-device", "xai-oauth", "gitlab-duo", "gitlab-duo-workflow", "alibaba-coding-plan", "aimlapi", "zhipu-coding-plan", "umans", "qwen-portal", "sakana", "minimax-code", "minimax-code-cn", "xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn", "firepass", "deepseek", "moonshot", "cerebras", "fireworks", "together", "nvidia", "huggingface", "perplexity", "qianfan", "venice", "synthetic", "nanogpt", "wafer-serverless", "coreweave", "vercel-ai-gateway", "cloudflare-ai-gateway", "litellm", "kilo", "zenmux", "opencode-zen", "opencode-go", "tavily", "kagi", "parallel", "ollama", "ollama-cloud", "lm-studio", "llama.cpp", "vllm", "openai", "google", "google-vertex", "xai", "groq", "mistral", "minimax", "amazon-bedrock"]

--- a/home/.chezmoidata/base/ai/agents/opencode.toml
+++ b/home/.chezmoidata/base/ai/agents/opencode.toml
@@ -25,10 +25,13 @@ disabled_agents = ["explore", "general", "scout"]
 plannotator = {workflow = "plan-agent", planning_agents = [
   "plan"
 ], plan_only = true}
-skills_paths = ["~/.config/opencode/profiles/factory/skills"]
+skills_paths = [
+  "~/.config/agents/libraries/skills/compound-engineering",
+  "~/.config/agents/libraries/skills/oh-my-opencode-slim"
+]
 
 [ai.base.agents.opencode.profiles.minimal]
-plugins = ["@tarquinen/opencode-dcp", "opencode-notify"]
+plugins = ["@tarquinen/opencode-dcp", "opencode-notify", "@slkiser/opencode-quota"]
 
 [ai.base.agents.opencode.sandbox.paths]
 allow_read = [

--- a/home/.chezmoidata/base/ai/libraries.toml
+++ b/home/.chezmoidata/base/ai/libraries.toml
@@ -23,20 +23,10 @@ opencode-caveman-config = {repository = "caveman", source = "src/hooks/caveman-c
 opencode-engram = {repo = "Gentleman-Programming/engram", ref = "main", source = "plugin/opencode/engram.ts", target = "libraries/extensions/opencode-engram/engram.ts"}
 
 [ai.base.libraries.repositories]
-caveman = {repo = "JuliusBrussee/caveman", ref = "v1.9.1"}
+caveman = {repo = "JuliusBrussee/caveman"}
 
 [ai.base.libraries.skills]
 caveman = {repository = "caveman", type = "file", source = "skills/caveman/SKILL.md"}
-karpathy = {repo = "multica-ai/andrej-karpathy-skills@main", include = [
-  "karpathy-guidelines"
-]}
-"oh-my-opencode-slim" = {repo = "alvinunreal/oh-my-opencode-slim", prefix = "src/skills", include = [
-  "simplify",
-  "codemap",
-  "clonedeps",
-  "deepwork",
-  "reflect",
-  "release-smoke-test",
-  "oh-my-opencode-slim",
-  "worktrees"
-]}
+compound-engineering = {repo = "EveryInc/compound-engineering-plugin", tag_prefix = "compound-engineering-", prefix = "skills"}
+karpathy = {repo = "multica-ai/andrej-karpathy-skills@main"}
+"oh-my-opencode-slim" = {repo = "alvinunreal/oh-my-opencode-slim", prefix = "src/skills"}

--- a/home/.chezmoidata/base/ai/models.toml
+++ b/home/.chezmoidata/base/ai/models.toml
@@ -3,14 +3,17 @@ port = 8321
 
 [ai.base.models.providers.github-copilot]
 auth_keys = []
+opencode_quota = "copilot"
 
 [ai.base.models.providers.openai-codex]
-aliases = {opencode = "openai"}
 auth_keys = []
+opencode_alias = "openai"
+opencode_quota = "openai"
 
 [ai.base.models.providers.opencode-go]
 api_key_env = "OPENCODE_API_KEY"
 auth_keys = ["opencode-go"]
+opencode_quota = "opencode-go"
 
 [ai.base.models.providers.openrouter]
 api_key_env = "OPENROUTER_API_KEY"

--- a/home/.chezmoidata/profile/personal/ai.toml
+++ b/home/.chezmoidata/profile/personal/ai.toml
@@ -1,9 +1,2 @@
-[ai.profile.personal.agents.omp.security]
-disabled_providers = [
-  "claude",
-  "gemini",
-  "github-copilot"
-]
-
 [ai.profile.personal.credentials]
 inject = ["BRAVE_SEARCH_API_KEY"]

--- a/home/.chezmoidata/profile/personal/models.toml
+++ b/home/.chezmoidata/profile/personal/models.toml
@@ -9,9 +9,9 @@ engine = "llamacpp"
 "qwen3.5-9b" = {name = "Qwen3.5 9B", reasoning = true, context_window = 65536, max_output = 8192, gguf = {repo = "unsloth/Qwen3.5-9B-GGUF", file = "Qwen3.5-9B-UD-Q6_K_XL.gguf"}, sampling = {min_p = 0.0, presence_penalty = 1.5, repetition_penalty = 1.0, temperature = 1.0, top_k = 20, top_p = 0.95}}
 
 [ai.profile.personal.models.council]
-alpha = {provider = "openai-codex", model = "gpt-5.6-sol", thinking = "high"}
-beta = {provider = "opencode-go", model = "glm-5.2", thinking = "high"}
-gamma = {provider = "opencode-go", model = "deepseek-v4-pro", thinking = "high"}
+alpha = {provider = "openai-codex", model = "gpt-5.6-sol", thinking = "high", fallbacks = [{provider = "opencode-go", model = "glm-5.2", thinking = "high"}]}
+beta = {provider = "opencode-go", model = "glm-5.2", thinking = "high", fallbacks = [{provider = "openai-codex", model = "gpt-5.6-sol", thinking = "high"}]}
+gamma = {provider = "opencode-go", model = "deepseek-v4-pro", thinking = "high", fallbacks = [{provider = "openai-codex", model = "gpt-5.6-luna", thinking = "high"}]}
 
 [ai.profile.personal.models.providers.openai-codex]
 enabled = true
@@ -27,8 +27,8 @@ models = []
 
 [ai.profile.personal.models.tiers]
 default = "medium"
-small = {provider = "opencode-go", model = "deepseek-v4-flash", thinking = "off"}
-medium = {provider = "opencode-go", model = "deepseek-v4-flash", thinking = "high"}
-big = {provider = "openai-codex", model = "gpt-5.6-luna", thinking = "high"}
-oracle = {provider = "openai-codex", model = "gpt-5.6-sol", thinking = "high"}
-visual = {provider = "opencode-go", model = "minimax-m3", thinking = "low"}
+small = {provider = "opencode-go", model = "deepseek-v4-flash", thinking = "off", fallbacks = [{provider = "openai-codex", model = "gpt-5.6-luna", thinking = "off"}]}
+medium = {provider = "opencode-go", model = "deepseek-v4-flash", thinking = "high", fallbacks = [{provider = "openai-codex", model = "gpt-5.6-luna", thinking = "high"}]}
+big = {provider = "openai-codex", model = "gpt-5.6-luna", thinking = "high", fallbacks = [{provider = "opencode-go", model = "deepseek-v4-pro", thinking = "high"}]}
+oracle = {provider = "openai-codex", model = "gpt-5.6-sol", thinking = "high", fallbacks = [{provider = "opencode-go", model = "glm-5.2", thinking = "high"}]}
+visual = {provider = "opencode-go", model = "minimax-m3", thinking = "low", fallbacks = [{provider = "openai-codex", model = "gpt-5.6-luna", thinking = "low"}]}

--- a/home/.chezmoidata/profile/work/ai.toml
+++ b/home/.chezmoidata/profile/work/ai.toml
@@ -1,11 +1,2 @@
-[ai.profile.work.agents.omp.security]
-disabled_providers = [
-  "claude",
-  "gemini",
-  "openai-codex",
-  "opencode-go",
-  "openrouter"
-]
-
 [ai.profile.work.credentials]
 inject = ["BRAVE_SEARCH_API_KEY"]

--- a/home/.chezmoitemplates/base/ai/render-library-archive
+++ b/home/.chezmoitemplates/base/ai/render-library-archive
@@ -18,4 +18,5 @@
     "repo" $repo
     "stripComponents" (add (len (splitList "/" $prefix)) 1)
     "include" $includes
+    "tagPrefix" (get . "tagPrefix" | default "")
     "exact" true) }}

--- a/home/.chezmoitemplates/base/ai/render-library-externals
+++ b/home/.chezmoitemplates/base/ai/render-library-externals
@@ -16,12 +16,15 @@
     "target" (printf "libraries/skills/%s/%s/SKILL.md" $alias $alias)
     "repo" $repo
     "source" $source
+    "tagPrefix" (get $skill "tag_prefix" | default "")
     "exact" true) }}
 {{-   else if eq $type "archive" -}}
 {{-     $prefix := get $skill "prefix" | default "skills" -}}
 {{-     $includes := get $skill "include" | default list -}}
-{{-     if eq (len $includes) 0 -}}{{- fail (printf "skills.%s: include is required for archive type" $alias) -}}{{- end -}}
-{{-     range $sub := $includes -}}
+{{-     $excludes := get $skill "exclude" | default list -}}
+{{-     $hasIncludes := gt (len $includes) 0 -}}
+{{-     if $hasIncludes -}}
+{{-       range $sub := $includes -}}
 {{ includeTemplate "base/github/external" (dict
     "type" "archive"
     "memo" $memo
@@ -29,7 +32,28 @@
     "repo" $repo
     "stripComponents" (add (len (splitList "/" $prefix)) 2)
     "include" (list (printf "*/%s/%s/**" $prefix $sub))
+    "tagPrefix" (get $skill "tag_prefix" | default "")
     "exact" true) }}
+{{-       end -}}
+{{-     else -}}
+{{-       $excludePatterns := list -}}
+{{-       range $ex := $excludes -}}
+{{-         $excludePatterns = append $excludePatterns (printf "*/%s/%s/**" $prefix $ex) -}}
+{{-       end -}}
+{{-       $archiveArgs := dict
+    "type" "archive"
+    "memo" $memo
+    "target" (printf "libraries/skills/%s" $alias)
+    "repo" $repo
+    "stripComponents" (add (len (splitList "/" $prefix)) 1)
+    "include" (list (printf "*/%s/**" $prefix))
+    "tagPrefix" (get $skill "tag_prefix" | default "")
+    "exact" true
+-}}
+{{-       if gt (len $excludePatterns) 0 -}}
+{{-         $_ := set $archiveArgs "exclude" $excludePatterns -}}
+{{-       end -}}
+{{ includeTemplate "base/github/external" $archiveArgs }}
 {{-     end -}}
 {{-   else -}}
 {{-     fail (printf "skills.%s: unsupported type %q" $alias $type) -}}
@@ -52,6 +76,7 @@
     "target" $targetRoot
     "prefix" (get $entry "prefix")
     "files" (get $entry "files")
+    "tagPrefix" (get $entry "tag_prefix" | default "")
     "label" $label) }}
 {{-     else if $hasSource -}}
 {{-       $source := get $entry "source" | default "" -}}
@@ -68,6 +93,7 @@
     "target" $target
     "repo" $repo
     "source" $source
+    "tagPrefix" (get $entry "tag_prefix" | default "")
     "exact" true) }}
 {{-     else -}}
 {{-       fail (printf "%s: files or source is required" $label) -}}

--- a/home/.chezmoitemplates/base/ai/render-opencode-model-id
+++ b/home/.chezmoitemplates/base/ai/render-opencode-model-id
@@ -2,7 +2,7 @@
   Render an OpenCode-compatible model ID string from a route config entry.
 
   Input: $route (dict with provider/model) or {route: $route, root: $root}
-  When root is provided, aliases are resolved from ai.models.providers metadata.
+  When root is provided, opencode_alias is resolved from ai.models.providers metadata.
   Output: "provider/model" or just "model" if no provider.
 */ -}}
 {{- $route := . -}}
@@ -14,8 +14,7 @@
   {{- if hasKey . "root" -}}
     {{- $providers := includeTemplate "base/helpers/load-section" (dict "root" .root "section" "ai.models.providers" "required" false) | mustFromJson -}}
     {{- $meta := get $providers $provider | default dict -}}
-    {{- $aliases := get $meta "aliases" | default dict -}}
-    {{- $aliasVal := get $aliases "opencode" | default "" -}}
+    {{- $aliasVal := get $meta "opencode_alias" | default "" -}}
     {{- if $aliasVal -}}{{- $ocProvider = $aliasVal -}}{{- end -}}
   {{- end -}}
   {{- printf "%s/%s" $ocProvider $model -}}

--- a/home/.chezmoitemplates/base/ai/render-opencode-slim-config
+++ b/home/.chezmoitemplates/base/ai/render-opencode-slim-config
@@ -3,7 +3,7 @@
 {{- $tiers := includeTemplate "base/helpers/load-section" (dict "root" $root "section" "ai.models.tiers" "required" true) | mustFromJson -}}
 
 
-{{- /* Mapping: slim agent -> tier */ -}}
+{{- /* Mapping: slim agent to tier */ -}}
 {{- $agentMap := dict
   "orchestrator" "big"
   "oracle" "oracle"
@@ -18,8 +18,10 @@
 {{- $engramMcps := list "engram" -}}
 {{- $librarianMcps := list "websearch" "context7" "gh_grep" -}}
 {{- $emptyMcps := list -}}
-{{- $orchestratorSkills := list "codemap" "clonedeps" "deepwork" "reflect" "release-smoke-test" "oh-my-opencode-slim" "worktrees" -}}
-{{- $oracleSkills := list "simplify" -}}
+{{- $orchestratorSkills := list "codemap" "clonedeps" "deepwork" "reflect" "loop-engineering" "oh-my-opencode-slim" "worktrees" "ce-brainstorm" "ce-ideate" "ce-plan" -}}
+{{- $oracleSkills := list "simplify" "ce-pov" "ce-doc-review" "ce-code-review" -}}
+{{- $designerSkills := list "ce-polish" "ce-test-browser" -}}
+{{- $fixerSkills := list "ce-work" "ce-debug" "ce-simplify-code" "ce-resolve-pr-feedback" -}}
 {{- $emptySkills := list -}}
 
 {{- /* Build managed preset */ -}}
@@ -30,12 +32,53 @@
 {{-     fail (printf "render-opencode-slim-config: ai.models.tiers has no route for tier %q (mapped by slim agent %q)" $tier $agent) -}}
 {{-   end -}}
 {{-   $cfg := dict -}}
-{{-   $_ := set $cfg "model" (includeTemplate "base/ai/render-opencode-model-id" (dict "route" $route "root" $root)) -}}
-{{-   if hasKey $route "thinking" -}}
-{{-     $thinking := $route.thinking -}}
-{{-     if ne $thinking "off" -}}
-{{-       $_ := set $cfg "variant" $thinking -}}
+{{-   $rawFallbacks := get $route "fallbacks" | default list -}}
+{{-   if or (not (kindIs "slice" $rawFallbacks)) (eq (len $rawFallbacks) 0) -}}
+{{-     $_ := set $cfg "model" (includeTemplate "base/ai/render-opencode-model-id" (dict "route" $route "root" $root)) -}}
+{{-     if hasKey $route "thinking" -}}
+{{-       $thinking := $route.thinking -}}
+{{-       if ne $thinking "off" -}}
+{{-         $_ := set $cfg "variant" $thinking -}}
+{{-       end -}}
 {{-     end -}}
+{{-   else -}}
+{{-     $models := list -}}
+{{-     $primaryId := includeTemplate "base/ai/render-opencode-model-id" (dict "route" $route "root" $root) -}}
+{{-     $primaryEntry := dict "id" $primaryId -}}
+{{-     if hasKey $route "thinking" -}}
+{{-       $thinking := $route.thinking -}}
+{{-       if ne $thinking "off" -}}
+{{-         $_ := set $primaryEntry "variant" $thinking -}}
+{{-       end -}}
+{{-     end -}}
+{{-     $models = append $models $primaryEntry -}}
+{{-     range $fbIdx, $fb := $rawFallbacks -}}
+{{-       if not (kindIs "map" $fb) -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] is not a map" $agent $fbIdx) -}}
+{{-       end -}}
+{{-       if not (and (hasKey $fb "provider") (hasKey $fb "model")) -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] missing provider/model" $agent $fbIdx) -}}
+{{-       end -}}
+{{-       if hasKey $fb "fallbacks" -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] has nested fallbacks" $agent $fbIdx) -}}
+{{-       end -}}
+{{-       if eq (get $fb "provider") "local" -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] uses provider=local" $agent $fbIdx) -}}
+{{-       end -}}
+{{-       $fbId := includeTemplate "base/ai/render-opencode-model-id" (dict "route" $fb "root" $root) -}}
+{{-       if not $fbId -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] resolved to empty ID" $agent $fbIdx) -}}
+{{-       end -}}
+{{-       $fbEntry := dict "id" $fbId -}}
+{{-       if hasKey $fb "thinking" -}}
+{{-         $fbThinking := $fb.thinking -}}
+{{-         if ne $fbThinking "off" -}}
+{{-           $_ := set $fbEntry "variant" $fbThinking -}}
+{{-         end -}}
+{{-       end -}}
+{{-       $models = append $models $fbEntry -}}
+{{-     end -}}
+{{-     $_ := set $cfg "model" $models -}}
 {{-   end -}}
 
 {{-   if eq $agent "orchestrator" -}}
@@ -47,6 +90,12 @@
 {{-   else if eq $agent "librarian" -}}
 {{-     $_ := set $cfg "mcps" $librarianMcps -}}
 {{-     $_ := set $cfg "skills" $emptySkills -}}
+{{-   else if eq $agent "designer" -}}
+{{-     $_ := set $cfg "mcps" $emptyMcps -}}
+{{-     $_ := set $cfg "skills" $designerSkills -}}
+{{-   else if eq $agent "fixer" -}}
+{{-     $_ := set $cfg "mcps" $emptyMcps -}}
+{{-     $_ := set $cfg "skills" $fixerSkills -}}
 {{-   else -}}
 {{-     $_ := set $cfg "mcps" $emptyMcps -}}
 {{-     $_ := set $cfg "skills" $emptySkills -}}
@@ -55,8 +104,7 @@
 {{-   $_ := set $presetAgents $agent $cfg -}}
 {{- end -}}
 
-{{- /* Build council councillors from per-profile ai.models.council map.
-  Each key is a councillor identity; value = {provider, model, thinking}. */ -}}
+{{- /* Build council councillors from per-profile ai.models.council map */ -}}
 {{- $councilMap := includeTemplate "base/helpers/load-section" (dict "root" $root "section" "ai.models.council" "required" true) | mustFromJson -}}
 {{- $councillors := dict -}}
 {{- range $name, $route := $councilMap -}}
@@ -65,17 +113,58 @@
 {{-     fail (printf "render-opencode-slim-config: council entry %q missing provider/model" $name) -}}
 {{-   end -}}
 {{-   $cfg := dict -}}
-{{-   $_ := set $cfg "model" (includeTemplate "base/ai/render-opencode-model-id" (dict "route" $route "root" $root)) -}}
-{{-   if hasKey $route "thinking" -}}
-{{-     $thinking := $route.thinking -}}
-{{-     if ne $thinking "off" -}}
-{{-       $_ := set $cfg "variant" $thinking -}}
+{{-   $rawFallbacks := get $route "fallbacks" | default list -}}
+{{-   if or (not (kindIs "slice" $rawFallbacks)) (eq (len $rawFallbacks) 0) -}}
+{{-     $_ := set $cfg "model" (includeTemplate "base/ai/render-opencode-model-id" (dict "route" $route "root" $root)) -}}
+{{-     if hasKey $route "thinking" -}}
+{{-       $thinking := $route.thinking -}}
+{{-       if ne $thinking "off" -}}
+{{-         $_ := set $cfg "variant" $thinking -}}
+{{-       end -}}
 {{-     end -}}
+{{-   else -}}
+{{-     $models := list -}}
+{{-     $primaryId := includeTemplate "base/ai/render-opencode-model-id" (dict "route" $route "root" $root) -}}
+{{-     $primaryEntry := dict "id" $primaryId -}}
+{{-     if hasKey $route "thinking" -}}
+{{-       $thinking := $route.thinking -}}
+{{-       if ne $thinking "off" -}}
+{{-         $_ := set $primaryEntry "variant" $thinking -}}
+{{-       end -}}
+{{-     end -}}
+{{-     $models = append $models $primaryEntry -}}
+{{-     range $fbIdx, $fb := $rawFallbacks -}}
+{{-       if not (kindIs "map" $fb) -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] is not a map" $name $fbIdx) -}}
+{{-       end -}}
+{{-       if not (and (hasKey $fb "provider") (hasKey $fb "model")) -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] missing provider/model" $name $fbIdx) -}}
+{{-       end -}}
+{{-       if hasKey $fb "fallbacks" -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] has nested fallbacks" $name $fbIdx) -}}
+{{-       end -}}
+{{-       if eq (get $fb "provider") "local" -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] uses provider=local" $name $fbIdx) -}}
+{{-       end -}}
+{{-       $fbId := includeTemplate "base/ai/render-opencode-model-id" (dict "route" $fb "root" $root) -}}
+{{-       if not $fbId -}}
+{{-         fail (printf "render-opencode-slim-config: %s fallback[%d] resolved to empty ID" $name $fbIdx) -}}
+{{-       end -}}
+{{-       $fbEntry := dict "id" $fbId -}}
+{{-       if hasKey $fb "thinking" -}}
+{{-         $fbThinking := $fb.thinking -}}
+{{-         if ne $fbThinking "off" -}}
+{{-           $_ := set $fbEntry "variant" $fbThinking -}}
+{{-         end -}}
+{{-       end -}}
+{{-       $models = append $models $fbEntry -}}
+{{-     end -}}
+{{-     $_ := set $cfg "model" $models -}}
 {{-   end -}}
 {{-   $_ := set $councillors $name $cfg -}}
 {{- end -}}
 {{- if eq (len $councillors) 0 -}}
-{{-   fail "render-opencode-slim-config: ai.models.council is empty — at least one councillor required" -}}
+{{-   fail "render-opencode-slim-config: ai.models.council is empty" -}}
 {{- end -}}
 
 {{- $councilPresets := dict "managed" $councillors -}}

--- a/home/.chezmoitemplates/base/ai/render-quota-toast-config
+++ b/home/.chezmoitemplates/base/ai/render-quota-toast-config
@@ -1,0 +1,44 @@
+{{- /* Render quota-toast config for @slkiser/opencode-quota plugin */ -}}
+{{- /* enabledProviders derived from merged model providers filtered by opencode_quota */ -}}
+{{- $root := .root -}}
+{{- $providers := includeTemplate "base/helpers/load-section" (dict "root" $root "section" "ai.models.providers" "required" false) | mustFromJson -}}
+{{- $enabledProviders := list -}}
+{{- range $id, $p := $providers -}}
+{{-   if get $p "enabled" | default false -}}
+{{-     $quota := get $p "opencode_quota" | default "" -}}
+{{-     if $quota -}}
+{{-       $enabledProviders = append $enabledProviders $quota -}}
+{{-     end -}}
+{{-   end -}}
+{{- end -}}
+{{- $cfg := dict
+  "enabled" true
+  "minIntervalMs" 300000
+  "requestTimeoutMs" 12000
+  "formatStyle" "allWindows"
+  "percentDisplayMode" "remaining"
+  "onlyCurrentModel" false
+  "showSessionTokens" true
+  "enableToast" false
+  "tuiSidebarPanel" (dict
+    "enabled" true
+    "formatStyle" "allWindows"
+  )
+  "tuiCompactStatus" (dict
+    "enabled" true
+    "homeBottom" true
+    "sessionPrompt" true
+    "suppressWhenNativeProviderQuota" true
+  )
+  "maintainerAnnouncements" (dict
+    "enabled" true
+    "home" true
+  )
+  "pricingSnapshot" (dict
+    "source" "auto"
+    "autoRefresh" 7
+  )
+  "enabledProviders" $enabledProviders
+  "opencodeGoWindows" (list "rolling" "weekly" "monthly")
+-}}
+{{- $cfg | toPrettyJson -}}

--- a/home/.chezmoitemplates/base/ai/resolve-enabled-auth-providers
+++ b/home/.chezmoitemplates/base/ai/resolve-enabled-auth-providers
@@ -55,6 +55,30 @@
 {{-       fail (printf "resolve-enabled-auth-providers: tier %q references %s but provider/model not enabled" $tierName $ref) -}}
 {{-     end -}}
 {{-   end -}}
+{{-   if hasKey $route "fallbacks" -}}
+{{-     $fallbacks := get $route "fallbacks" -}}
+{{-     if not (kindIs "slice" $fallbacks) -}}
+{{-       fail (printf "resolve-enabled-auth-providers: tier %q fallbacks must be a list" $tierName) -}}
+{{-     end -}}
+{{-     range $idx, $fallback := $fallbacks -}}
+{{-       if not (kindIs "map" $fallback) -}}
+{{-         fail (printf "resolve-enabled-auth-providers: tier %q fallback[%d] must be a route map" $tierName $idx) -}}
+{{-       end -}}
+{{-       if hasKey $fallback "fallbacks" -}}
+{{-         fail (printf "resolve-enabled-auth-providers: tier %q fallback[%d] cannot nest fallbacks" $tierName $idx) -}}
+{{-       end -}}
+{{-       if not (and (hasKey $fallback "provider") (hasKey $fallback "model")) -}}
+{{-         fail (printf "resolve-enabled-auth-providers: tier %q fallback[%d] missing provider/model" $tierName $idx) -}}
+{{-       end -}}
+{{-       if eq (get $fallback "provider") "local" -}}
+{{-         fail (printf "resolve-enabled-auth-providers: tier %q fallback[%d] cannot use local provider" $tierName $idx) -}}
+{{-       end -}}
+{{-       $fallbackRef := printf "%s/%s" $fallback.provider $fallback.model -}}
+{{-       if not (has $fallbackRef $enabledModels) -}}
+{{-         fail (printf "resolve-enabled-auth-providers: tier %q fallback[%d] references %s but provider/model not enabled" $tierName $idx $fallbackRef) -}}
+{{-       end -}}
+{{-     end -}}
+{{-   end -}}
 {{- end -}}
 {{- $councilMap := includeTemplate "base/helpers/load-section" (dict "root" $root "section" "ai.models.council" "required" false) | mustFromJson -}}
 {{- range $name, $route := $councilMap -}}
@@ -63,6 +87,30 @@
 {{-     $ref := printf "%s/%s" $route.provider $route.model -}}
 {{-     if not (has $ref $enabledModels) -}}
 {{-       fail (printf "resolve-enabled-auth-providers: council entry %q references %s but provider/model not enabled" $name $ref) -}}
+{{-     end -}}
+{{-   end -}}
+{{-   if hasKey $route "fallbacks" -}}
+{{-     $fallbacks := get $route "fallbacks" -}}
+{{-     if not (kindIs "slice" $fallbacks) -}}
+{{-       fail (printf "resolve-enabled-auth-providers: council entry %q fallbacks must be a list" $name) -}}
+{{-     end -}}
+{{-     range $idx, $fallback := $fallbacks -}}
+{{-       if not (kindIs "map" $fallback) -}}
+{{-         fail (printf "resolve-enabled-auth-providers: council entry %q fallback[%d] must be a route map" $name $idx) -}}
+{{-       end -}}
+{{-       if hasKey $fallback "fallbacks" -}}
+{{-         fail (printf "resolve-enabled-auth-providers: council entry %q fallback[%d] cannot nest fallbacks" $name $idx) -}}
+{{-       end -}}
+{{-       if not (and (hasKey $fallback "provider") (hasKey $fallback "model")) -}}
+{{-         fail (printf "resolve-enabled-auth-providers: council entry %q fallback[%d] missing provider/model" $name $idx) -}}
+{{-       end -}}
+{{-       if eq (get $fallback "provider") "local" -}}
+{{-         fail (printf "resolve-enabled-auth-providers: council entry %q fallback[%d] cannot use local provider" $name $idx) -}}
+{{-       end -}}
+{{-       $fallbackRef := printf "%s/%s" $fallback.provider $fallback.model -}}
+{{-       if not (has $fallbackRef $enabledModels) -}}
+{{-         fail (printf "resolve-enabled-auth-providers: council entry %q fallback[%d] references %s but provider/model not enabled" $name $idx $fallbackRef) -}}
+{{-       end -}}
 {{-     end -}}
 {{-   end -}}
 {{- end -}}

--- a/home/.chezmoitemplates/base/github/external
+++ b/home/.chezmoitemplates/base/github/external
@@ -6,10 +6,13 @@
     source          — file path inside repo (required when type = "file")
     stripComponents — int, default 1 (archive only)
     include         — list of glob patterns (archive only)
+    exclude         — list of glob patterns to exclude (archive only)
     exact           — bool, emits `exact = true`
     refreshPeriod   — string, default "168h" (only honored when @ref is set)
     memo            — optional dict for caching gitHubTags lookups across calls
-  Without @ref, the latest git tag is used; repos with no tags will error. */ -}}
+    tagPrefix       — string, filter tags by prefix before picking latest (no @ref only)
+  Without @ref, the latest git tag is used (optionally filtered by tagPrefix);
+  repos with no matching tags will error. */ -}}
 {{- $type := .type -}}
 {{- if and (ne $type "archive") (ne $type "file") -}}
 {{-   fail (printf "base/github/external: unknown type %q (want \"archive\" or \"file\")" $type) -}}
@@ -20,21 +23,52 @@
 {{- if gt (len $repoParts) 1 -}}{{- $ref = index $repoParts 1 -}}{{- end -}}
 {{- if not $ref -}}
 {{-   $tags := list -}}
+{{- /* Fetch tags via GitHub API with ?per_page=100 to avoid pagination issues. */ -}}
 {{-   if index . "memo" -}}
 {{-     $memo := index . "memo" -}}
 {{-     if hasKey $memo $repoName -}}
 {{-       $tags = index $memo $repoName -}}
 {{-     else -}}
-{{-       $tags = gitHubTags $repoName -}}
+{{-       $url := printf "https://api.github.com/repos/%s/tags?per_page=100" $repoName -}}
+{{-       $token := env "GITHUB_TOKEN" | default "" -}}
+{{-       if $token -}}
+{{-         $tags = output "curl" "-s" "-H" (printf "Authorization: Bearer %s" $token) $url | fromJson -}}
+{{-       else -}}
+{{-         $tags = output "curl" "-s" $url | fromJson -}}
+{{-       end -}}
+{{-       if not (kindIs "slice" $tags) -}}
+{{-         fail (printf "base/github/external: failed to fetch tags for %s" $repoName) -}}
+{{-       end -}}
 {{-       $_ := set $memo $repoName $tags -}}
 {{-     end -}}
 {{-   else -}}
-{{-     $tags = gitHubTags $repoName -}}
+{{-     $url := printf "https://api.github.com/repos/%s/tags?per_page=100" $repoName -}}
+{{-     $token := env "GITHUB_TOKEN" | default "" -}}
+{{-     if $token -}}
+{{-       $tags = output "curl" "-s" "-H" (printf "Authorization: Bearer %s" $token) $url | fromJson -}}
+{{-     else -}}
+{{-       $tags = output "curl" "-s" $url | fromJson -}}
+{{-     end -}}
+{{-     if not (kindIs "slice" $tags) -}}
+{{-       fail (printf "base/github/external: failed to fetch tags for %s" $repoName) -}}
+{{-     end -}}
+{{-   end -}}
+{{-   $tagPrefix := get . "tagPrefix" | default "" -}}
+{{-   if $tagPrefix -}}
+{{-     $filtered := list -}}
+{{-     range $tag := $tags -}}
+{{-       if hasPrefix $tagPrefix $tag.name -}}
+{{-         $filtered = append $filtered $tag -}}
+{{-       end -}}
+{{-     end -}}
+{{-     $tags = $filtered -}}
 {{-   end -}}
 {{-   if not (gt (len $tags) 0) -}}
-{{-     fail (printf "base/github/external: %s has no git tags; pin a branch with @ref" $repoName) -}}
+{{-     $msg := printf "base/github/external: %s has no matching tags" $repoName -}}
+{{-     if $tagPrefix -}}{{- $msg = printf "%s with prefix %q" $msg $tagPrefix -}}{{- end -}}
+{{-     fail (printf "%s; pin a branch with @ref" $msg) -}}
 {{-   end -}}
-{{-   $ref = (index $tags 0).Name -}}
+{{-   $ref = (index $tags 0).name -}}
 {{- end -}}
 {{- $isTag := not (gt (len $repoParts) 1) -}}
 ["{{ .target }}"]
@@ -48,6 +82,9 @@
     stripComponents = {{ default 1 (index . "stripComponents") }}
 {{-   if index . "include" }}
     include = [{{ range $i, $p := index . "include" }}{{ if $i }}, {{ end }}"{{ $p }}"{{ end }}]
+{{-   end }}
+{{-   if index . "exclude" }}
+    exclude = [{{ range $i, $p := index . "exclude" }}{{ if $i }}, {{ end }}"{{ $p }}"{{ end }}]
 {{-   end }}
 {{- else if eq $type "file" }}
     type = "file"

--- a/home/.chezmoitemplates/base/helpers/render-model-category-map
+++ b/home/.chezmoitemplates/base/helpers/render-model-category-map
@@ -5,7 +5,7 @@
     root  — chezmoi data root (required)
     field — category field to render, usually "agents" or "skills" (default: "agents")
 
-  Output: JSON dict of mappedName → {model, thinking, fallbackModels?},
+  Output: JSON dict of mappedName → {model, thinking},
   where model is "provider/model" when provider is set.
 */ -}}
 {{- $root := .root -}}
@@ -26,9 +26,6 @@
 {{-   range $name := $names -}}
 {{-     $model := includeTemplate "base/ai/render-pi-model-ref" $route -}}
 {{-     $config := dict "model" $model "thinking" $route.thinking -}}
-{{-     if hasKey $route "fallback" -}}
-{{-       $_ := set $config "fallbackModels" $route.fallback -}}
-{{-     end -}}
 {{-     $result = merge $result (dict $name $config) -}}
 {{-   end -}}
 {{- end -}}

--- a/home/private_dot_config/exact_greywall/greywall.json.tmpl
+++ b/home/private_dot_config/exact_greywall/greywall.json.tmpl
@@ -26,7 +26,7 @@
 -}}
 {{- dict
   "network" $network
-  "filesystem" (dict "defaultDenyRead" true "allowRead" $fs.allowRead "allowWrite" $fs.allowWrite "denyRead" $fs.denyRead "denyWrite" $fs.denyWrite)
+  "filesystem" (dict "defaultDenyRead" true "allowGitConfig" true "allowRead" $fs.allowRead "allowWrite" $fs.allowWrite "denyRead" $fs.denyRead "denyWrite" $fs.denyWrite)
   "command" (dict "deny" $cmdDeny "useDefaults" true)
   "ssh" $ssh
   "credentials" (dict "inject" $creds.inject "secrets" $creds.secrets "ignore" $creds.ignore)

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_core/opencode-quota/symlink_quota-toast.json.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_core/opencode-quota/symlink_quota-toast.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/opencode/opencode-quota/quota-toast.json

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_clonedeps.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_clonedeps.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/.config/agents/libraries/skills/oh-my-opencode-slim/clonedeps

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_codemap.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_codemap.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/.config/agents/libraries/skills/oh-my-opencode-slim/codemap

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_deepwork.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_deepwork.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/.config/agents/libraries/skills/oh-my-opencode-slim/deepwork

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_oh-my-opencode-slim.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_oh-my-opencode-slim.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/.config/agents/libraries/skills/oh-my-opencode-slim/oh-my-opencode-slim

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_reflect.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_reflect.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/.config/agents/libraries/skills/oh-my-opencode-slim/reflect

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_release-smoke-test.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_release-smoke-test.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/.config/agents/libraries/skills/oh-my-opencode-slim/release-smoke-test

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_simplify.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_simplify.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/.config/agents/libraries/skills/oh-my-opencode-slim/simplify

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_worktrees.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/exact_skills/symlink_worktrees.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/.config/agents/libraries/skills/oh-my-opencode-slim/worktrees

--- a/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/opencode-quota/symlink_quota-toast.json.tmpl
+++ b/home/private_dot_config/exact_opencode/exact_profiles/exact_factory/opencode-quota/symlink_quota-toast.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/opencode/opencode-quota/quota-toast.json

--- a/home/private_dot_config/exact_opencode/opencode-quota/quota-toast.json.tmpl
+++ b/home/private_dot_config/exact_opencode/opencode-quota/quota-toast.json.tmpl
@@ -1,0 +1,2 @@
+{{- /* quota-toast.json sidecar for @slkiser/opencode-quota plugin (minimal) */ -}}
+{{ includeTemplate "base/ai/render-quota-toast-config" (dict "root" .) }}

--- a/home/private_dot_config/exact_private_omp/private_security.yml.tmpl
+++ b/home/private_dot_config/exact_private_omp/private_security.yml.tmpl
@@ -1,7 +1,23 @@
 # Managed security overlay for OMP — rendered from layered data.
 # Injected via --config after user args; overrides user-facing config.
 # Do not edit directly.
-{{- $s := includeTemplate "base/helpers/load-section" (dict "root" . "section" "ai.agents.omp.security" "required" true) | mustFromJson }}
+{{ $s := includeTemplate "base/helpers/load-section" (dict "root" . "section" "ai.agents.omp.security" "required" true) | mustFromJson }}
+{{- /* Derive disabledProviders from ai.agents.omp.settings.providers static universe */ -}}
+{{- $ompSettings := includeTemplate "base/helpers/load-section" (dict "root" . "section" "ai.agents.omp.settings" "required" true) | mustFromJson -}}
+{{- $allProviders := get $ompSettings "providers" | default list -}}
+{{- $providers := includeTemplate "base/helpers/load-section" (dict "root" . "section" "ai.models.providers" "required" false) | mustFromJson -}}
+{{- $enabled := list -}}
+{{- range $id, $p := $providers -}}
+{{-   if and (has $id $allProviders) (get $p "enabled" | default false) -}}
+{{-     $enabled = append $enabled $id -}}
+{{-   end -}}
+{{- end -}}
+{{- $disabled := list -}}
+{{- range $p := $allProviders -}}
+{{-   if not (has $p $enabled) -}}
+{{-     $disabled = append $disabled $p -}}
+{{-   end -}}
+{{- end }}
 tools:
   approvalMode: {{ $s.tools.approval_mode }}
   discoveryMode: {{ $s.tools.discovery_mode }}
@@ -34,7 +50,7 @@ commands:
   enableOpencodeProject: {{ $s.commands.enable_opencode_project }}
 
 disabledProviders:
-{{- range $s.disabled_providers }}
+{{- range $disabled }}
   - {{ . }}
 {{- end }}
 

--- a/home/private_dot_local/exact_bin/executable_agent-launch.tmpl
+++ b/home/private_dot_local/exact_bin/executable_agent-launch.tmpl
@@ -156,9 +156,9 @@ preflight_update() {
         fi
       done
       if [ "$missing" -gt 0 ]; then
-        warn "Dependencies: $missing plugin(s) need install — startup may be slow"
+        warn "Plugins: $missing uncached (normal; opencode-agent factory startup resolves packages)"
       else
-        ok "Dependencies: cached"
+        ok "Plugins: cached"
       fi
       ;;
     omp)

--- a/home/private_dot_local/share/exact_dotfiles/exact_test/test-ai-omp.bats.tmpl
+++ b/home/private_dot_local/share/exact_dotfiles/exact_test/test-ai-omp.bats.tmpl
@@ -197,10 +197,16 @@ make_test_home() {
   assert_yq '.disabledProviders | length > 0' "$SECURITY_FILE"
   assert_yq '.startup.checkUpdate == false and .startup.setupWizard == false' "$SECURITY_FILE"
 {{- if eq .host.profile "personal" }}
+  # enabled providers: openai-codex, opencode-go, openrouter — must NOT be disabled
   assert_yq '(.disabledProviders | map(select(. == "openai-codex")) | length == 0) and (.disabledProviders | map(select(. == "opencode-go")) | length == 0) and (.disabledProviders | map(select(. == "openrouter")) | length == 0)' "$SECURITY_FILE"
+  # representative built-in providers that are not enabled must be disabled
+  assert_yq '(.disabledProviders | map(select(. == "anthropic")) | length == 1) and (.disabledProviders | map(select(. == "google")) | length == 1) and (.disabledProviders | map(select(. == "github-copilot")) | length == 1)' "$SECURITY_FILE"
 {{- end }}
 {{- if eq .host.profile "work" }}
-  assert_yq '(.disabledProviders | map(select(. == "github-copilot")) | length == 0) and (.disabledProviders | map(select(. == "openai-codex")) | length == 1) and (.disabledProviders | map(select(. == "opencode-go")) | length == 1) and (.disabledProviders | map(select(. == "openrouter")) | length == 1)' "$SECURITY_FILE"
+  # enabled providers: github-copilot — must NOT be disabled
+  assert_yq '(.disabledProviders | map(select(. == "github-copilot")) | length == 0)' "$SECURITY_FILE"
+  # representative built-in providers that are not enabled must be disabled
+  assert_yq '(.disabledProviders | map(select(. == "anthropic")) | length == 1) and (.disabledProviders | map(select(. == "google")) | length == 1) and (.disabledProviders | map(select(. == "openai-codex")) | length == 1)' "$SECURITY_FILE"
 {{- end }}
 }
 
@@ -234,6 +240,19 @@ make_test_home() {
   assert_jq '.credentials.secrets | length > 0' "$GREYWALL_FILE"
   assert_jq '.network.allowUnixSockets | index("~/.local/share/tmux") != null' "$GREYWALL_FILE"
   assert_jq '(.network.forwardPorts // []) | index(7437) != null' "$GREYWALL_FILE"
+}
+
+# bats test_tags=toolchain:omp,kind:greywall
+@test "omp greywall learned profile inherits allowGitConfig from base" {
+  local BASE_GREYWALL="$HOME/.config/greywall/greywall.json"
+  assert_file_exists "$GREYWALL_FILE"
+  assert_file_exists "$BASE_GREYWALL"
+  # Confirms learned profile does not override allowGitConfig (inherits from base)
+  run jq -e '(.filesystem | has("allowGitConfig") | not)' "$GREYWALL_FILE"
+  assert_success
+  # Confirms base config has the flag enabled
+  run jq -e '.filesystem.allowGitConfig == true' "$BASE_GREYWALL"
+  assert_success
 }
 
 # ── Credentials renderer ──

--- a/home/private_dot_local/share/exact_dotfiles/exact_test/test-ai-opencode.bats.tmpl
+++ b/home/private_dot_local/share/exact_dotfiles/exact_test/test-ai-opencode.bats.tmpl
@@ -91,6 +91,8 @@ setup() {
   assert_output --partial "--no-greywall"
   assert_output --partial "--no-update"
   assert_output --partial "opencode args"
+  assert_output --partial "core"
+  assert_output --partial "factory"
 }
 
 # bats test_tags=toolchain:opencode,kind:config
@@ -176,12 +178,129 @@ EOF
 }
 
 # bats test_tags=toolchain:opencode,kind:config
-@test "opencode factory profile includes key plugins" {
+@test "opencode factory profile includes key plugins without Compound plugin" {
   run jq -e '
     (.plugin | index("oh-my-opencode-slim") != null) and
+    (.plugin | index("compound-engineering@git+https://github.com/EveryInc/compound-engineering-plugin.git") == null) and
     any(.plugin[]; type == "array" and .[0] == "@plannotator/opencode@latest")
   ' "$HOME/.config/opencode/profiles/factory/opencode.json"
   assert_success
+}
+
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode quota plugin registered in all profiles" {
+  run jq -e '
+    .plugin | index("@slkiser/opencode-quota") != null
+  ' "$HOME/.config/opencode/opencode.json"
+  assert_success
+  run jq -e '
+    .plugin | index("@slkiser/opencode-quota") != null
+  ' "$HOME/.config/opencode/profiles/core/opencode.json"
+  assert_success
+  run jq -e '
+    .plugin | index("@slkiser/opencode-quota") != null
+  ' "$HOME/.config/opencode/profiles/factory/opencode.json"
+  assert_success
+}
+
+{{- /* quota-toast sidecar paths per profile */ -}}
+{{- $quotaProfiles := list "minimal" "core" "factory" -}}
+{{- $quotaPaths := dict
+  "minimal" "opencode/opencode-quota/quota-toast.json"
+  "core" "opencode/profiles/core/opencode-quota/quota-toast.json"
+  "factory" "opencode/profiles/factory/opencode-quota/quota-toast.json"
+-}}
+
+{{- range $qProfile := list "minimal" }}
+{{-   $qPath := index $quotaPaths $qProfile }}
+
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode {{ $qProfile }} quota-toast config file exists" {
+  assert_file_exists "$HOME/.config/{{ $qPath }}"
+  run jq -e '.enabled == true' "$HOME/.config/{{ $qPath }}"
+  assert_success
+}
+
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode {{ $qProfile }} quota-toast stable settings" {
+  run jq -e '
+    .minIntervalMs == 300000 and
+    .requestTimeoutMs == 12000 and
+    .formatStyle == "allWindows" and
+    .percentDisplayMode == "remaining" and
+    .onlyCurrentModel == false and
+    .showSessionTokens == true and
+    .enableToast == false
+  ' "$HOME/.config/{{ $qPath }}"
+  assert_success
+}
+
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode {{ $qProfile }} quota-toast sidebar and compact status" {
+  run jq -e '
+    .tuiSidebarPanel.enabled == true and
+    .tuiSidebarPanel.formatStyle == "allWindows" and
+    .tuiCompactStatus.enabled == true and
+    .tuiCompactStatus.homeBottom == true and
+    .tuiCompactStatus.sessionPrompt == true and
+    .tuiCompactStatus.suppressWhenNativeProviderQuota == true
+  ' "$HOME/.config/{{ $qPath }}"
+  assert_success
+}
+
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode {{ $qProfile }} quota-toast announcements and pricing" {
+  run jq -e '
+    .maintainerAnnouncements.enabled == true and
+    .maintainerAnnouncements.home == true and
+    .pricingSnapshot.source == "auto" and
+    .pricingSnapshot.autoRefresh == 7
+  ' "$HOME/.config/{{ $qPath }}"
+  assert_success
+}
+
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode {{ $qProfile }} quota-toast opencode windows" {
+  run jq -e '
+    (.opencodeGoWindows | index("rolling") != null) and
+    (.opencodeGoWindows | index("weekly") != null) and
+    (.opencodeGoWindows | index("monthly") != null)
+  ' "$HOME/.config/{{ $qPath }}"
+  assert_success
+}
+{{- end }}
+
+{{- range $qProfile := $quotaProfiles }}
+{{-   $qPath := index $quotaPaths $qProfile }}
+{{-   if eq $.host.profile "personal" }}
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode {{ $qProfile }} quota-toast personal enabledProviders" {
+  run jq -e '
+    (.enabledProviders | index("openai") != null) and
+    (.enabledProviders | index("opencode-go") != null) and
+    (.enabledProviders | index("openrouter") == null) and
+    (.enabledProviders | length) == 2
+  ' "$HOME/.config/{{ $qPath }}"
+  assert_success
+}
+{{-   end }}
+{{-   if eq $.host.profile "work" }}
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode {{ $qProfile }} quota-toast work enabledProviders" {
+  run jq -e '
+    (.enabledProviders | index("copilot") != null) and
+    (.enabledProviders | length) == 1
+  ' "$HOME/.config/{{ $qPath }}"
+  assert_success
+}
+{{-   end }}
+{{- end }}
+
+# bats test_tags=toolchain:opencode,kind:symlink
+@test "opencode core and factory quota sidecars link to default config" {
+  target="$HOME/.config/opencode/opencode-quota/quota-toast.json"
+  assert_symlink_to "$target" "$HOME/.config/opencode/profiles/core/opencode-quota/quota-toast.json"
+  assert_symlink_to "$target" "$HOME/.config/opencode/profiles/factory/opencode-quota/quota-toast.json"
 }
 
 # bats test_tags=toolchain:opencode,kind:config
@@ -265,15 +384,91 @@ EOF
   assert_success
 }
 
+{{- if eq .host.profile "personal" }}
 # bats test_tags=toolchain:opencode,kind:model
-@test "opencode factory slim configures managed agents" {
+# Personal: tier routes include fallbacks, so .model is an array.
+{{- range $agent, $tier := $ocSlimAgentCategories }}
+{{-   $route := index $ocTiers $tier }}
+{{-   if and $route (ne $agent "council") (hasKey $route "fallbacks") }}
+# bats test_tags=toolchain:opencode,kind:model,tier:routing
+@test "opencode factory slim {{ $agent }} personal chain has fallback with resolved remote ID" {
   run jq -e '
-    (.presets.managed.orchestrator.model | length > 0) and
-    (.presets.managed.oracle.model | length > 0) and
-    (.council.presets.managed.alpha.model | length > 0)
+    (.presets.managed.{{ $agent }}.model | type) == "array" and
+    (.presets.managed.{{ $agent }}.model | length) >= 2 and
+    (.presets.managed.{{ $agent }}.model[0].id | length > 0) and
+    (.presets.managed.{{ $agent }}.model[1].id | length > 0) and
+    (.presets.managed.{{ $agent }}.model[1].id | startswith("openai/") or startswith("opencode-go/"))
   ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
 }
+{{-   end }}
+{{- end }}
+# bats test_tags=toolchain:opencode,kind:model,tier:routing
+@test "opencode factory slim personal council fallbacks have resolved remote IDs" {
+  run jq -e '
+    all(.council.presets.managed[]; (.model | type) == "array") and
+    all(.council.presets.managed[]; (.model | length) >= 2) and
+    all(.council.presets.managed[]; (.model[0].id | length > 0)) and
+    all(.council.presets.managed[]; (.model[1].id | length > 0)) and
+    all(.council.presets.managed[]; (.model[1].id | startswith("openai/") or startswith("opencode-go/")))
+  ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  assert_success
+}
+
+# bats test_tags=toolchain:opencode,kind:model,tier:routing
+@test "opencode factory slim personal chains have per-entry variant where thinking non-off" {
+  run jq -e '
+    any(.presets.managed[]; any(.model[]; has("variant"))) and
+    any(.presets.managed[]; any(.model[]; has("variant") | not)) and
+    all(.presets.managed[].model[]; if has("variant") then (.variant | length > 0) else true end)
+  ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  assert_success
+  run jq -e '
+    all(.council.presets.managed[].model[]; has("variant") and (.variant | length > 0))
+  ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  assert_success
+}
+
+# bats test_tags=toolchain:opencode,kind:model,tier:routing
+@test "opencode factory slim personal fallback uses different remote provider than primary" {
+  run jq -e '
+    all(.presets.managed[];
+      (.model[0].id | split("/")[0]) != (.model[1].id | split("/")[0])
+    ) and
+    all(.council.presets.managed[];
+      (.model[0].id | split("/")[0]) != (.model[1].id | split("/")[0])
+    )
+  ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  assert_success
+}
+{{- end }}
+
+{{- if eq .host.profile "work" }}
+# bats test_tags=toolchain:opencode,kind:model,tier:routing
+# Work: no fallbacks configured — agents emit singular .model string, no .models.
+@test "opencode factory slim work agents have singular string model (no fallback chain)" {
+  run jq -e '
+    all(.presets.managed[]; (.model | type) == "string") and
+    all(.presets.managed[]; has("models") | not) and
+    all(.presets.managed[]; .model | startswith("github-copilot/"))
+  ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  assert_success
+  run jq -e '
+    all(.council.presets.managed[]; (.model | type) == "string") and
+    all(.council.presets.managed[]; has("models") | not) and
+    all(.council.presets.managed[]; .model | startswith("github-copilot/"))
+  ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  assert_success
+}
+
+# bats test_tags=toolchain:opencode,kind:model,tier:routing
+@test "opencode factory slim work agents have no local/fallback provider in model" {
+  run jq -e '
+    all(.presets.managed[]; (.model | startswith("local/") | not))
+  ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  assert_success
+}
+{{- end }}
 
 # bats test_tags=toolchain:opencode,kind:config
 @test "opencode factory profile marks plan and build as primary agents" {
@@ -307,8 +502,10 @@ EOF
 }
 
 # bats test_tags=toolchain:opencode,kind:config
-@test "opencode slim oracle has simplify skill" {
-  run jq -e '.presets.managed.oracle.skills | index("simplify") != null' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+@test "opencode slim orchestrator owns Compound brainstorming skills" {
+  run jq -e '.presets.managed.orchestrator.skills | index("ce-brainstorm") != null and index("ce-ideate") != null and index("ce-plan") != null' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  assert_success
+  run jq -e '.presets.managed.oracle.skills | index("simplify") != null and index("ce-brainstorm") == null' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
 }
 
@@ -344,15 +541,23 @@ EOF
 # bats test_tags=toolchain:opencode,kind:config
 @test "opencode oh-my-opencode-slim skill library is linked" {
   assert_file_exists "$HOME/.config/agents/libraries/skills/oh-my-opencode-slim/simplify/SKILL.md"
-  assert_file_exists "$HOME/.config/agents/libraries/skills/oh-my-opencode-slim/release-smoke-test/SKILL.md"
+  assert_file_exists "$HOME/.config/agents/libraries/skills/oh-my-opencode-slim/loop-engineering/SKILL.md"
 }
 
-# bats test_tags=toolchain:opencode,kind:symlink
-@test "opencode factory profile skill symlink resolves" {
-  link="$HOME/.config/opencode/profiles/factory/skills/simplify"
-  assert_symlink_to "$HOME/.config/agents/libraries/skills/oh-my-opencode-slim/simplify" "$link"
-  link="$HOME/.config/opencode/profiles/factory/skills/release-smoke-test"
-  assert_symlink_to "$HOME/.config/agents/libraries/skills/oh-my-opencode-slim/release-smoke-test" "$link"
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode Compound skill library is linked" {
+  assert_file_exists "$HOME/.config/agents/libraries/skills/compound-engineering/ce-brainstorm/SKILL.md"
+  assert_file_exists "$HOME/.config/agents/libraries/skills/compound-engineering/ce-plan/SKILL.md"
+  assert_file_exists "$HOME/.config/agents/libraries/skills/compound-engineering/lfg/SKILL.md"
+}
+
+# bats test_tags=toolchain:opencode,kind:config
+@test "opencode factory config skills.paths contains both library roots" {
+  run jq -e '
+    (.skills.paths | index("~/.config/agents/libraries/skills/compound-engineering") != null) and
+    (.skills.paths | index("~/.config/agents/libraries/skills/oh-my-opencode-slim") != null)
+  ' "$HOME/.config/opencode/profiles/factory/opencode.json"
+  assert_success
 }
 
 # bats test_tags=toolchain:opencode,kind:symlink
@@ -446,53 +651,25 @@ EOF
 }
 # bats test_tags=toolchain:opencode,kind:config
 # bats test_tags=toolchain:opencode,kind:model,tier:routing
-@test "opencode factory slim all agents have non-empty models" {
+@test "opencode factory slim all agents have non-empty model" {
   run jq -e '
-    all(
-      .presets.managed[];
-      (.model | length > 0)
-    )
-  ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
-  assert_success
-}
-
-{{- range $agent, $tier := $ocSlimAgentCategories }}
-{{- $route := index $ocTiers $tier }}
-{{- if and $route (ne $agent "council") }}
-
-# bats test_tags=toolchain:opencode,kind:model,tier:routing
-@test "opencode factory slim {{ $agent }} routes to {{ $tier }} tier model" {
-  run jq -e '.presets.managed.{{ $agent }}.model | length > 0' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
-  assert_success
-}
-{{- end }}
-{{- end }}
-
-# bats test_tags=toolchain:opencode,kind:model,tier:routing
-@test "opencode factory slim all councilors have non-empty models" {
-  run jq -e '
-    all(
-      .council.presets.managed[];
-      (.model | length > 0)
-    )
+    all(.presets.managed[]; (.model | length > 0))
   ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
 }
 
 # bats test_tags=toolchain:opencode,kind:model,tier:routing
-@test "opencode factory slim council councillors are diverse (not all same model)" {
+@test "opencode factory slim all councilors have non-empty model" {
   run jq -e '
-    ([.council.presets.managed[] | .model] | unique | length) >= 2
+    all(.council.presets.managed[]; (.model | length > 0))
   ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
 }
 
 # bats test_tags=toolchain:opencode,kind:model,tier:routing
-@test "opencode factory slim council has alpha beta gamma councillors" {
+@test "opencode factory slim council councillors models are diverse" {
   run jq -e '
-    .council.presets.managed.alpha.model and
-    .council.presets.managed.beta.model and
-    .council.presets.managed.gamma.model
+    ([.council.presets.managed[] | if (.model | type) == "string" then .model else .model[0].id end] | unique | length) >= 2
   ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
 }
@@ -500,34 +677,24 @@ EOF
 {{- if eq .host.profile "personal" }}
 # bats test_tags=toolchain:opencode,kind:model,tier:routing
 @test "opencode factory slim personal agents use correct provider prefixes" {
-  run jq -e '.presets.managed.oracle.model | startswith("openai/")' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  run jq -e '.presets.managed.oracle.model[0].id | startswith("openai/")' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
-  run jq -e '.presets.managed.designer.model | startswith("opencode-go/")' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  run jq -e '.presets.managed.designer.model[0].id | startswith("opencode-go/")' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
-  run jq -e '.council.presets.managed.alpha.model | startswith("openai/")' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
+  run jq -e '.council.presets.managed.alpha.model[0].id | startswith("openai/")' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
 }
 {{- end }}
 
 {{- if eq .host.profile "work" }}
 # bats test_tags=toolchain:opencode,kind:model,tier:routing
-@test "opencode factory slim work routes use only github-copilot provider" {
+@test "opencode factory slim work agents use only github-copilot provider" {
   run jq -e '
-    all(
-      .presets.managed[];
-      (.model | startswith("github-copilot/"))
-    )
+    all(.presets.managed[]; (.model | startswith("github-copilot/")))
   ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
-}
-
-# bats test_tags=toolchain:opencode,kind:model,tier:routing
-@test "opencode factory slim work council routes use only github-copilot provider" {
   run jq -e '
-    all(
-      .council.presets.managed[];
-      (.model | startswith("github-copilot/"))
-    )
+    all(.council.presets.managed[]; (.model | startswith("github-copilot/")))
   ' "$HOME/.config/opencode/profiles/factory/oh-my-opencode-slim.json"
   assert_success
 }
@@ -637,14 +804,6 @@ SCRIPT
   assert_output --partial "opencode/opencode.json"
   assert_output --partial "OPENCODE_CONFIG_DIR"
   assert_output --partial "opencode"
-}
-
-# bats test_tags=toolchain:opencode,kind:config
-@test "opencode-agent help mentions profiles" {
-  run "$HOME/.local/bin/opencode-agent" --help
-  assert_success
-  assert_output --partial "core"
-  assert_output --partial "factory"
 }
 
 # bats test_tags=kind:opencode

--- a/home/private_dot_local/share/exact_dotfiles/exact_test/test-ai-permissions.bats.tmpl
+++ b/home/private_dot_local/share/exact_dotfiles/exact_test/test-ai-permissions.bats.tmpl
@@ -201,6 +201,7 @@ setup() {
   assert_file_exists "{{ $greywallDir }}/greywall.json"
   run jq -e '
     .filesystem.defaultDenyRead == true and
+    .filesystem.allowGitConfig == true and
     (.filesystem.allowWrite | index("**") == null) and
     (.filesystem.allowWrite | index(".*/**") == null) and
     (.filesystem.denyRead | index("~/.ssh/id_*") != null) and
@@ -306,7 +307,8 @@ setup() {
     (.filesystem.allowWrite | index("~/.config/pi/profiles/core/**") != null) and
     (.filesystem.allowWrite | index("~/.config/pi/profiles/factory/**") != null) and
     (.filesystem.allowRead | index("~/.config/pi/**") != null) and
-    (.network.rules[] | select(.destination == "pi.dev" and (.port | tostring) == "443" and .action == "allow"))
+    (.network.rules[] | select(.destination == "pi.dev" and (.port | tostring) == "443" and .action == "allow")) and
+    ($global[0].filesystem.allowGitConfig == true)
   ' "{{ $greywallDir }}/learned/pi.json"
   assert_success
   run jq -e ".network.allowUnixSockets | index(\"~/.local/share/tmux\") != null" "{{ $greywallDir }}/learned/pi.json"
@@ -325,7 +327,8 @@ setup() {
     (.credentials == $global[0].credentials) and
     (.filesystem.allowWrite | index("~/.local/share/opencode") != null) and
     (.filesystem.allowRead | index("~/.config/opencode/**") != null) and
-    (.network.forwardPorts // [] | map(tostring) | index("19432") != null)
+    (.network.forwardPorts // [] | map(tostring) | index("19432") != null) and
+    ($global[0].filesystem.allowGitConfig == true)
   ' "{{ $greywallDir }}/learned/opencode.json"
   assert_success
   run jq -e ".network.allowUnixSockets | index(\"~/.local/share/tmux\") != null" "{{ $greywallDir }}/learned/opencode.json"


### PR DESCRIPTION
- Flatten provider metadata to opencode_alias/opencode_quota; use static 65-item
  OMP settings.providers for disabled-provider derivation
- Rolling latest compound-engineering-* tag via tag_prefix; unpin Caveman ref
- Library filtering defaults to all skills with optional exclude; remove stale
  OMO include lists and release-smoke-test references
- Replace factory OMO per-skill symlinks with one direct oh-my-opencode-slim
  library path; expose compound-engineering as a library root
- Simplify redundant OpenCode tests (19 removed, 189 remaining)
- Add quota-toast render template and core/factory sidecar symlinks
